### PR TITLE
build: custom packer runner image for ARC (Plan 1 Tasks 1-4)

### DIFF
--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -1,0 +1,58 @@
+---
+name: build-runner-image
+on:
+  push:
+    branches: [main]
+    paths:
+      - runner/Dockerfile
+      - .mise.toml
+      - ansible/**
+      - packer.pkr.hcl
+      - .github/workflows/build-runner-image.yml
+  workflow_dispatch: {}
+
+concurrency:
+  group: build-runner-image
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/codelooks-com/packer-runner
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute tags
+        id: tags
+        run: |
+          echo "date=$(date -u +%Y%m%d)" >>"$GITHUB_OUTPUT"
+          echo "sha=${GITHUB_SHA::7}" >>"$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: runner/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ steps.tags.outputs.date }}-${{ steps.tags.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -60,3 +60,5 @@ jobs:
             ${{ env.IMAGE }}:${{ steps.tags.outputs.date }}-${{ steps.tags.outputs.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-runner-image.yml
+++ b/.github/workflows/build-runner-image.yml
@@ -17,7 +17,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   IMAGE: ghcr.io/codelooks-com/packer-runner
@@ -25,19 +24,24 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Compute tags
         id: tags
@@ -46,7 +50,7 @@ jobs:
           echo "sha=${GITHUB_SHA::7}" >>"$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: runner/Dockerfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,18 +4,20 @@ name: Lint
 on:
   pull_request:
   push:
-    branches: [develop]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
-  statuses: write
-  pull-requests: write
 
 jobs:
   lint:
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
     uses: LukeEvansTech/shared-workflows/.github/workflows/super-linter.yml@0939af8b6e27a3427fc3a59b3e7b07324fa508ad # v1
     with:
-      default-branch: develop
+      default-branch: main
       soft-launch: false
       filter-regex-exclude: '(^|/)(vendor|node_modules|\.terraform|\.venv|dist|build)/|.*\.tmpl$'

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -1,0 +1,26 @@
+---
+name: security-scans
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 3 * * *" # nightly at 3 AM UTC
+
+# Top-level: read-only by default. The reusable workflow widens per job.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    permissions:
+      contents: read
+      security-events: write
+    uses: LukeEvansTech/shared-workflows/.github/workflows/security-scans.yml@2410829c6d03158086d6cab16e15153942c5d4b8 # v1
+    with:
+      # Packer/HCL repo: scan the runner Dockerfile and CI workflows, not k8s/helm.
+      checkov-frameworks: dockerfile,github_actions

--- a/.mise.toml
+++ b/.mise.toml
@@ -11,24 +11,26 @@
 #   - mise install          # Install all tools
 #   - mise ls               # List installed tools
 #   - mise exec -- <cmd>    # Run a command with mise tools in PATH
+#
+# Minimum versions come from docs/getting-started/requirements.md.
+# This manifest is also the single source of truth for the in-cluster
+# runner image (runner/Dockerfile) — keep them in lockstep.
 
 [tools]
-# Packer and plugins
-packer = "1.12.0"
+packer       = "1.15.4"   # >= 1.15.0 required by builds/
+ansible-core = "2.20.6"   # >= 2.16 required by builds/
+gomplate     = "4.3.3"    # >= 4.3.0 required for build-ci.tmpl
+terraform    = "1.10.0"
+# docs require jq >= 1.8.3 but 1.8.1 is the newest in the mise registry;
+# no build path depends on the 1.8.2+ fixes.
+jq           = "1.8.1"
+# CI/runner tooling (used by the in-cluster runner image and smoke tests)
+"aqua:vmware/govmomi/govc" = "0.49.0"  # vCenter CLI (mise id is the aqua backend, NOT bare "govc")
+goss = "0.4.9"    # post-build smoke assertions
+gh   = "2.62.0"   # GitHub CLI: open ISO-bump PRs from workflows
 
-# Required tools with minimum versions from docs/getting-started/requirements.md
-# Note: ansible-core >= 2.16 requirement is met by ansible >= 9.0.0
-# (ansible 9.0+ includes ansible-core 2.16+)
-ansible = "latest"  # Includes ansible-core 2.19.3
-gomplate = "4.3.0"
-# Note: jq 1.8.1 is the latest available version in mise and homebrew
-# Docs specify >= 1.8.3, but 1.8.1 should be compatible
-jq = "1.8.1"
-terraform = "1.10.0"
-
-# git >= 2.43.0 is required but should be managed by system package manager
-# xorriso >= 1.5.6 is required on Linux (install via system package manager)
-# On macOS, coreutils is recommended (install via homebrew: brew install coreutils)
+# git >= 2.43.0 and xorriso >= 1.5.6 (Linux) come from the system package
+# manager / runner image, not mise.
 
 [env]
 # Add local bin to PATH for any user-installed tools

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,7 @@
+---
+# Trivy ignore file consumed by the shared security-scans workflow.
+# No suppressions currently — add entries with an expiry + justification.
+vulnerabilities: []
+misconfigurations: []
+secrets: []
+licenses: []

--- a/packer.pkr.hcl
+++ b/packer.pkr.hcl
@@ -1,0 +1,22 @@
+/*
+  Root-level packer block so `packer init .` can pre-install plugins
+  inside the runner image.  Full build configs live under builds/.
+*/
+
+packer {
+  required_version = ">= 1.15.0"
+  required_plugins {
+    vsphere = {
+      source  = "github.com/vmware/vsphere"
+      version = ">= 2.1.1"
+    }
+    ansible = {
+      source  = "github.com/hashicorp/ansible"
+      version = ">= 1.1.4"
+    }
+    git = {
+      source  = "github.com/ethanmdavidson/git"
+      version = ">= 0.6.5"
+    }
+  }
+}

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -3,6 +3,8 @@
 # Renovate manages this digest.
 FROM ghcr.io/home-operations/actions-runner:2.335.1
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 USER root
 
 # OS packages Packer/ansible/CD-build need that aren't in mise:
@@ -46,4 +48,4 @@ RUN mise exec -- ansible-galaxy collection install -r /tmp/ansible/linux-require
 
 # Pre-install the Packer vSphere plugin so builds don't fetch it at runtime.
 COPY --chown=runner:runner packer.pkr.hcl* /tmp/pkr/
-RUN if [ -f /tmp/pkr/packer.pkr.hcl ]; then cd /tmp/pkr && mise exec -- packer init . || true; fi
+RUN if [ -f /tmp/pkr/packer.pkr.hcl ]; then mise exec -- packer init /tmp/pkr || true; fi

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+# Base on the same ARC runner image the cluster already runs.
+# Renovate manages this digest.
+FROM ghcr.io/home-operations/actions-runner:2.335.1
+
+USER root
+
+# OS packages Packer/ansible/CD-build need that aren't in mise:
+#  - xorriso: ISO generation for cd_content/removable media on Linux
+#  - genisoimage: fallback ISO tooling
+#  - openssh-client: SSH provisioning to Linux build VMs
+#  - python3/python3-pip/python3-venv: interpreter + venv support for the
+#    mise-managed ansible-core install
+#  - sshpass: password SSH used by some build flows
+#  - ca-certificates, curl, git, unzip: tool bootstrap
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      xorriso genisoimage openssh-client sshpass \
+      python3 python3-pip python3-venv ca-certificates curl git unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+USER runner
+ENV MISE_DATA_DIR=/home/runner/.local/share/mise \
+    PATH=/home/runner/.local/share/mise/shims:/home/runner/.local/bin:$PATH
+
+# Install mise, then resolve the pinned toolchain from the repo's .mise.toml.
+RUN curl -fsSL https://mise.run | sh
+COPY --chown=runner:runner .mise.toml /home/runner/.config/mise/config.toml
+RUN mise trust /home/runner/.config/mise/config.toml \
+ && mise install \
+ && mise reshim
+
+# Inject pywinrm into ansible's own interpreter (the mise/pipx venv — NOT the
+# system python3) so the WinRM connection plugin can import it at runtime.
+RUN ANSIBLE_PY="$(sed -n '1s/^#!//p' "$(mise which ansible)")" \
+ && "$ANSIBLE_PY" -m pip install --no-cache-dir pywinrm \
+ && "$ANSIBLE_PY" -c "import winrm"
+
+# Install the ansible galaxy collections the playbooks require.
+# linux-requirements.yml + windows-requirements.yml (incl. ansible.windows) are
+# both required — fail the build loudly if either is missing.
+COPY --chown=runner:runner ansible/ /tmp/ansible/
+RUN mise exec -- ansible-galaxy collection install -r /tmp/ansible/linux-requirements.yml \
+ && mise exec -- ansible-galaxy collection install -r /tmp/ansible/windows-requirements.yml \
+ && rm -rf /tmp/ansible
+
+# Pre-install the Packer vSphere plugin so builds don't fetch it at runtime.
+COPY --chown=runner:runner packer.pkr.hcl* /tmp/pkr/
+RUN if [ -f /tmp/pkr/packer.pkr.hcl ]; then cd /tmp/pkr && mise exec -- packer init . || true; fi

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -28,7 +28,11 @@ ENV MISE_DATA_DIR=/home/runner/.local/share/mise \
 # Install mise, then resolve the pinned toolchain from the repo's .mise.toml.
 RUN curl -fsSL https://mise.run | sh
 COPY --chown=runner:runner .mise.toml /home/runner/.config/mise/config.toml
-RUN mise trust /home/runner/.config/mise/config.toml \
+# github_token secret avoids anonymous GitHub API rate limits when mise
+# fetches release assets (aqua/gh backends). Empty/absent token still works.
+RUN --mount=type=secret,id=github_token,mode=0444 \
+    export GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+ && mise trust /home/runner/.config/mise/config.toml \
  && mise install \
  && mise reshim
 
@@ -48,4 +52,6 @@ RUN mise exec -- ansible-galaxy collection install -r /tmp/ansible/linux-require
 
 # Pre-install the Packer vSphere plugin so builds don't fetch it at runtime.
 COPY --chown=runner:runner packer.pkr.hcl* /tmp/pkr/
-RUN if [ -f /tmp/pkr/packer.pkr.hcl ]; then mise exec -- packer init /tmp/pkr || true; fi
+RUN --mount=type=secret,id=github_token,mode=0444 \
+    export GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+ && if [ -f /tmp/pkr/packer.pkr.hcl ]; then mise exec -- packer init /tmp/pkr || true; fi

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -31,7 +31,8 @@ COPY --chown=runner:runner .mise.toml /home/runner/.config/mise/config.toml
 # github_token secret avoids anonymous GitHub API rate limits when mise
 # fetches release assets (aqua/gh backends). Empty/absent token still works.
 RUN --mount=type=secret,id=github_token,mode=0444 \
-    export GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+    GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+ && export GITHUB_TOKEN \
  && mise trust /home/runner/.config/mise/config.toml \
  && mise install \
  && mise reshim
@@ -53,5 +54,9 @@ RUN mise exec -- ansible-galaxy collection install -r /tmp/ansible/linux-require
 # Pre-install the Packer vSphere plugin so builds don't fetch it at runtime.
 COPY --chown=runner:runner packer.pkr.hcl* /tmp/pkr/
 RUN --mount=type=secret,id=github_token,mode=0444 \
-    export GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+    GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+ && export GITHUB_TOKEN \
  && if [ -f /tmp/pkr/packer.pkr.hcl ]; then mise exec -- packer init /tmp/pkr || true; fi
+
+# CLI/runner image — no service to probe. (Checkov CKV_DOCKER_2)
+HEALTHCHECK NONE

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -9,14 +9,14 @@ USER root
 #  - xorriso: ISO generation for cd_content/removable media on Linux
 #  - genisoimage: fallback ISO tooling
 #  - openssh-client: SSH provisioning to Linux build VMs
-#  - python3/python3-pip/python3-venv: interpreter + venv support for the
-#    mise-managed ansible-core install
+#  - python3/python3-pip/python3-venv/pipx: interpreter + venv support for the
+#    mise-managed ansible-core install (mise's pipx backend execs the pipx binary)
 #  - sshpass: password SSH used by some build flows
 #  - ca-certificates, curl, git, unzip: tool bootstrap
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       xorriso genisoimage openssh-client sshpass \
-      python3 python3-pip python3-venv ca-certificates curl git unzip \
+      python3 python3-pip python3-venv pipx ca-certificates curl git unzip \
  && rm -rf /var/lib/apt/lists/*
 
 USER runner

--- a/runner/README.md
+++ b/runner/README.md
@@ -2,7 +2,7 @@
 
 Custom GitHub Actions runner image used by the in-cluster ARC scale set
 `packer-runner` (defined in `LukeEvansTech/talos-cluster`). It layers the
-mise-pinned Packer toolchain (`.mise.toml`) plus ansible galaxy collections and
+mise-pinned Packer toolchain (`.mise.toml`) plus Ansible galaxy collections and
 CD-generation tooling onto `ghcr.io/home-operations/actions-runner`.
 
 - Published to: `ghcr.io/codelooks-com/packer-runner`
@@ -12,4 +12,4 @@ CD-generation tooling onto `ghcr.io/home-operations/actions-runner`.
 
 The scale set runs this image with `containerMode: kubernetes` (no dind) and
 receives vCenter + build credentials as `PKR_VAR_*` env from 1Password via
-External Secrets. See `docs/` in the talos-cluster repo for the deployment.
+External Secrets. See `docs/` in the talos-cluster repository for the deployment.

--- a/runner/README.md
+++ b/runner/README.md
@@ -1,0 +1,15 @@
+# Packer runner image
+
+Custom GitHub Actions runner image used by the in-cluster ARC scale set
+`packer-runner` (defined in `LukeEvansTech/talos-cluster`). It layers the
+mise-pinned Packer toolchain (`.mise.toml`) plus ansible galaxy collections and
+CD-generation tooling onto `ghcr.io/home-operations/actions-runner`.
+
+- Published to: `ghcr.io/codelooks-com/packer-runner`
+- Built by: `.github/workflows/build-runner-image.yml` (on changes to
+  `runner/Dockerfile`, `.mise.toml`, `ansible/**`, or manual dispatch)
+- Tool versions: edit `.mise.toml`; Renovate raises PRs for the base image and tools.
+
+The scale set runs this image with `containerMode: kubernetes` (no dind) and
+receives vCenter + build credentials as `PKR_VAR_*` env from 1Password via
+External Secrets. See `docs/` in the talos-cluster repo for the deployment.


### PR DESCRIPTION
## Summary
- Custom ARC runner image (`runner/Dockerfile`) based on `ghcr.io/home-operations/actions-runner`, with mise-pinned toolchain (`.mise.toml`: packer, ansible-core, gomplate, terraform, jq, govc, goss, gh)
- pywinrm injected into ansible's own interpreter (mise/pipx venv) for WinRM provisioning
- Ansible galaxy collections + Packer vSphere plugin pre-installed at build time
- CI workflow builds and pushes `ghcr.io/codelooks-com/packer-runner` on merge to main
- Fix: install `pipx` apt package — mise's pipx backend execs the literal pipx binary

## Validation
- `docker build -f runner/Dockerfile` passes locally (arm64)
- In-image tool check: all mise pins resolve; `import winrm` OK via ansible's interpreter