### PR TITLE
feat: build pipeline thin slice — ubuntu 24.04 on the cluster runner (Plan 2)

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -13,6 +13,11 @@ concurrency:
   group: build-templates
   cancel-in-progress: false
 
+# Cancellation note: -on-error=cleanup covers packer-detected failures but
+# NOT workflow cancellation (SIGTERM) — a cancelled run can leave a
+# 'linux-ubuntu-24.04-lts-*' VM behind. The next run's -force (build.sh)
+# deletes the same-named VM at build start; manual govc cleanup also works.
+
 jobs:
   ubuntu-2404:
     runs-on: packer-vsphere
@@ -27,15 +32,49 @@ jobs:
           persist-credentials: false
 
       - name: Build Ubuntu Server 24.04 LTS
-        run: ./build.sh --ci --os Linux --dist "Ubuntu Server" --version "24.04" "$GITHUB_WORKSPACE/ci/config"
+        run: |
+          set -euo pipefail
+          ./build.sh --ci --os Linux --dist "Ubuntu Server" --version "24.04" "$GITHUB_WORKSPACE/ci/config"
 
-      - name: Upload build evidence
+      # Manifests contain only non-sensitive build metadata — safe to retain.
+      - name: Upload build manifest
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ubuntu-2404-build
-          path: |
-            packer-build.log
-            manifests/*.json
+          path: manifests/*.json
           if-no-files-found: warn
           retention-days: 14
+
+      # PACKER_LOG=1 plugin debug traces can carry secrets the console
+      # masking never sees (e.g. the interpolated shutdown_command) — and
+      # artifacts on a public repo are downloadable by any authenticated
+      # GitHub user. Redact every sensitive PKR_VAR_* value before upload,
+      # and upload the log only when the build failed (triage-only).
+      - name: Scrub secrets from debug log
+        if: failure()
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, pathlib
+          p = pathlib.Path("packer-build.log")
+          if p.exists():
+              data = p.read_text(errors="replace")
+              for k, v in os.environ.items():
+                  lk = k.lower()
+                  if k.startswith("PKR_VAR_") and v and ("password" in lk or "key" in lk):
+                      data = data.replace(v, f"[REDACTED:{k}]")
+              p.write_text(data)
+              print("scrubbed", p)
+          else:
+              print("no packer-build.log to scrub")
+          PY
+
+      - name: Upload debug log (failures only)
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ubuntu-2404-build-debug-log
+          path: packer-build.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -52,6 +52,7 @@ jobs:
       # GitHub user. Redact every sensitive PKR_VAR_* value before upload,
       # and upload the log only when the build failed (triage-only).
       - name: Scrub secrets from debug log
+        id: scrub
         if: failure()
         run: |
           set -euo pipefail
@@ -71,7 +72,9 @@ jobs:
           PY
 
       - name: Upload debug log (failures only)
-        if: failure()
+        # Gate on scrub success — if the scrub step itself failed, failure()
+        # alone would still upload the RAW (unscrubbed) log.
+        if: failure() && steps.scrub.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ubuntu-2404-build-debug-log

--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -36,6 +36,17 @@ jobs:
           set -euo pipefail
           ./build.sh --ci --os Linux --dist "Ubuntu Server" --version "24.04" "$GITHUB_WORKSPACE/ci/config"
 
+      # upload-artifact v4 rejects ':' in file paths, and the engine names
+      # manifests with a 'YYYY-MM-DD hh:mm:ss' timestamp — rename first.
+      - name: Rename manifests for artifact upload
+        if: always()
+        run: |
+          set -euo pipefail
+          for f in manifests/*.json; do
+            [ -e "$f" ] || continue
+            mv "$f" "${f//[ :]/-}"
+          done
+
       # Manifests contain only non-sensitive build metadata — safe to retain.
       - name: Upload build manifest
         if: always()

--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -1,0 +1,41 @@
+---
+name: build-templates
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Date-stamp-free engine naming means two concurrent runs would race to
+# create the same VM name — serialize.
+concurrency:
+  group: build-templates
+  cancel-in-progress: false
+
+jobs:
+  ubuntu-2404:
+    runs-on: packer-vsphere
+    timeout-minutes: 150
+    env:
+      PACKER_LOG: "1"
+      PACKER_LOG_PATH: ${{ github.workspace }}/packer-build.log
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Build Ubuntu Server 24.04 LTS
+        run: ./build.sh --ci --os Linux --dist "Ubuntu Server" --version "24.04" "$GITHUB_WORKSPACE/ci/config"
+
+      - name: Upload build evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ubuntu-2404-build
+          path: |
+            packer-build.log
+            manifests/*.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,7 @@ jobs:
     with:
       default-branch: main
       soft-launch: false
-      filter-regex-exclude: '(^|/)(vendor|node_modules|\.terraform|\.venv|dist|build)/|.*\.tmpl$'
+      # build.sh/download.sh/config.sh/set-envvars.sh are vendored from
+      # upstream vmware/packer-examples-for-vsphere — not house style; we
+      # carry minimal surgical diffs and re-merge upstream periodically.
+      filter-regex-exclude: '(^|/)(vendor|node_modules|\.terraform|\.venv|dist|build)/|.*\.tmpl$|(^|/)(build|download|config|set-envvars)\.sh$'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - builds/**
       - ci/config/**
+      - build.sh
+      - project.json
       - .github/workflows/validate.yml
 
 permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,58 @@
+---
+name: validate
+
+on:
+  pull_request:
+    paths:
+      - builds/**
+      - ci/config/**
+      - .github/workflows/validate.yml
+
+permissions:
+  contents: read
+
+# Dummy credentials only: packer validate never contacts vCenter, and
+# PR-triggered jobs run GitHub-hosted — real creds exist only on the
+# self-hosted runner, which dispatch-only workflows use.
+env:
+  PKR_VAR_vsphere_endpoint: vc.example.com
+  PKR_VAR_vsphere_username: dummy@example.com
+  PKR_VAR_vsphere_password: dummy
+  PKR_VAR_vsphere_insecure_connection: "true"
+  PKR_VAR_vsphere_cluster: vSAN Cluster
+  PKR_VAR_vsphere_datastore: vsanDatastore
+  PKR_VAR_vsphere_network: VM Network
+  PKR_VAR_build_password: dummy
+  PKR_VAR_build_password_encrypted: $6$dummy$dummy
+  PKR_VAR_build_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDummyDummyDummyDummyDummyDummyDummyDummy dummy
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232 # v3.1.0
+        with:
+          version: "1.15.4"
+
+      - name: Packer fmt
+        run: packer fmt -check -recursive builds/linux/ubuntu/24-04-lts ci/config
+
+      - name: Packer validate (ubuntu 24.04 thin slice)
+        run: |
+          packer init builds/linux/ubuntu/24-04-lts
+          packer validate \
+            -var-file=ci/config/vsphere.pkrvars.hcl \
+            -var-file=ci/config/build.pkrvars.hcl \
+            -var-file=ci/config/ansible.pkrvars.hcl \
+            -var-file=ci/config/proxy.pkrvars.hcl \
+            -var-file=ci/config/common.pkrvars.hcl \
+            -var-file=ci/config/network.pkrvars.hcl \
+            -var-file=ci/config/linux-storage.pkrvars.hcl \
+            -var-file=ci/config/linux-ubuntu-24-04-lts.pkrvars.hcl \
+            builds/linux/ubuntu/24-04-lts

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ terraform.rc
 
 # Configurations
 ## Ignore default config directory.
-config/
+/config/
 
 # Artifacts
 ## Ignore artifacts directory.

--- a/build.sh
+++ b/build.sh
@@ -686,6 +686,11 @@ select_build() {
         printf "\n\033[0;31m✘ Error:\033[0m The build directory does not exist: \033[0;34m$INPUT_PATH\033[0m.\n"
 
         if [ "$auto_continue" = true ]; then
+            # CI mode: a missing build directory is fatal — retrying via the
+            # version menu would recurse forever with --version pre-set.
+            if [ "$ci_mode" = true ]; then
+                exit 1
+            fi
             printf "\n\033[0;36m➜ Auto-continue is enabled. Skipping user prompt and retrying...\033[0m\n"
             select_version  # Retry automatically.
         else

--- a/build.sh
+++ b/build.sh
@@ -87,6 +87,7 @@ show_help() {
     printf "  \033[0;34m --version\033[0m            Specify the version of the distribution.\n"
     printf "  \033[0;34m --edition\033[0m            Specify the edition (e.g., 'Standard', 'Datacenter').\n"
     printf "  \033[0;34m --auto-continue\033[0m      Automatically continue without user prompts.\n"
+    printf "  \033[0;34m --ci\033[0m                 Non-interactive CI mode: implies --auto-continue, -on-error=cleanup, exits with the build status.\n"
     printf "  \033[0;34m --show, -s, -S\033[0m       Display the build command used to build the image.\n"
     printf "\033[0;34m config_path:\033[0m\n"
     printf "  \033[0m Path to save the generated configuration files. (Optional).\n\n"
@@ -212,6 +213,8 @@ dist=""
 version=""
 edition=""
 auto_continue=false
+ci_mode=false
+on_error_option="-on-error=ask"
 
 # Script options.
 while (("$#")); do
@@ -241,6 +244,11 @@ while (("$#")); do
         version="$2"
         shift 2
         ;;
+    --ci)
+        ci_mode=true
+        auto_continue=true
+        shift
+        ;;
     --auto-continue)
         auto_continue=true
         shift
@@ -269,6 +277,12 @@ done
 # After the loop, check if show_help needs to be run
 if $run_show_help; then
     show_help
+fi
+
+# CI mode: never prompt on failure; clean up the failed VM so a retry
+# is not blocked by a name clash.
+if [ "$ci_mode" = true ]; then
+    on_error_option="-on-error=cleanup"
 fi
 
 if $run_check_dependencies; then
@@ -784,7 +798,7 @@ select_build() {
         var_files=("vsphere_vars" "build_vars" "ansible_vars" "proxy_vars" "common_vars" "network_vars" "storage_vars" "BUILD_VARS")
         validate_linux_username "$config_path/build.pkrvars.hcl"
         printf "Starting the build of %s %s...\n\n" "$dist" "$version"
-        command="packer build -force -on-error=ask $debug_option"
+        command="packer build -force $on_error_option $debug_option"
 
         for var_file in "${var_files[@]}"; do
             command+=" -var-file=\"$config_path/${!var_file}\""
@@ -798,13 +812,13 @@ select_build() {
             printf "\n\e[34m%s\e[0m\n" "$command"
         fi
 
-        eval "$command"
+        eval "$command"; build_rc=$?
         ;;
     "Red Hat Enterprise Linux")
         var_files=("vsphere_vars" "build_vars" "ansible_vars" "proxy_vars" "common_vars" "network_vars" "storage_vars" "rshm_vars" "BUILD_VARS")
         validate_linux_username "$config_path/build.pkrvars.hcl"
         printf "Starting the build of %s %s...\n\n" "$dist" "$version"
-        command="packer build -force -on-error=ask $debug_option"
+        command="packer build -force $on_error_option $debug_option"
 
         for var_file in "${var_files[@]}"; do
             command+=" -var-file=\"$config_path/${!var_file}\""
@@ -818,13 +832,13 @@ select_build() {
             printf "\n\e[34m%s\e[0m\n" "$command"
         fi
 
-        eval "$command"
+        eval "$command"; build_rc=$?
         ;;
     "VMware Photon OS")
         var_files=("vsphere_vars" "build_vars" "ansible_vars" "proxy_vars" "common_vars" "network_vars" "BUILD_VARS")
         validate_linux_username "$config_path/build.pkrvars.hcl"
         printf "Starting the build of %s %s...\n\n" "$dist" "$version"
-        command="packer build -force -on-error=ask $debug_option"
+        command="packer build -force $on_error_option $debug_option"
 
         for var_file in "${var_files[@]}"; do
             command+=" -var-file=\"$config_path/${!var_file}\""
@@ -838,13 +852,13 @@ select_build() {
             printf "\n\e[34m%s\e[0m\n" "$command"
         fi
 
-        eval "$command"
+        eval "$command"; build_rc=$?
         ;;
     "SUSE Linux Enterprise Server")
         var_files=("vsphere_vars" "build_vars" "ansible_vars" "network_vars" "proxy_vars" "common_vars" "scc_vars" "BUILD_VARS")
         validate_linux_username "$config_path/build.pkrvars.hcl"
         printf "Starting the build of %s %s...\n\n" "$dist" "$version"
-        command="packer build -force -on-error=ask $debug_option"
+        command="packer build -force $on_error_option $debug_option"
 
         for var_file in "${var_files[@]}"; do
             command+=" -var-file=\"$config_path/${!var_file}\""
@@ -858,7 +872,7 @@ select_build() {
             printf "\n\e[34m%s\e[0m\n" "$command"
         fi
 
-        eval "$command"
+        eval "$command"; build_rc=$?
         ;;
     "Windows Server")
         case "$edition" in
@@ -867,7 +881,7 @@ select_build() {
             build_username=$(grep 'build_username' "$config_path/build.pkrvars.hcl" | awk -F '"' '{print $2}')
             validate_windows_username "$config_path/build.pkrvars.hcl"
             printf "Starting the build of %s %s...\n\n" "$dist" "$version"
-            command="packer build -force -on-error=ask $debug_option"
+            command="packer build -force $on_error_option $debug_option"
             command+=" --only=vsphere-iso.windows-server-standard-dexp,vsphere-iso.windows-server-standard-core"
 
             for var_file in "${var_files[@]}"; do
@@ -882,13 +896,13 @@ select_build() {
                 printf "\n\e[34m%s\e[0m\n" "$command"
             fi
 
-            eval "$command"
+            eval "$command"; build_rc=$?
             ;;
         "Datacenter")
             var_files=("vsphere_vars" "build_vars" "ansible_vars" "proxy_vars" "common_vars" "BUILD_VARS")
             validate_windows_username "$config_path/build.pkrvars.hcl"
             printf "Starting the build of %s %s...\n\n" "$dist" "$version"
-            command="packer build -force -on-error=ask $debug_option"
+            command="packer build -force $on_error_option $debug_option"
             command+=" --only vsphere-iso.windows-server-datacenter-dexp,vsphere-iso.windows-server-datacenter-core"
 
             for var_file in "${var_files[@]}"; do
@@ -903,7 +917,7 @@ select_build() {
                 printf "\n\e[34m%s\e[0m\n" "$command"
             fi
 
-            eval "$command"
+            eval "$command"; build_rc=$?
             ;;
         *)
             print_message error "Unsupported $dist edition: $edition"
@@ -916,7 +930,7 @@ select_build() {
             var_files=("vsphere_vars" "build_vars" "ansible_vars" "proxy_vars" "common_vars" "BUILD_VARS")
             validate_windows_username "$config_path/build.pkrvars.hcl"
             printf "Starting the build of %s %s...\n\n" "$dist" "$version"
-            command="packer build -force -on-error=ask $debug_option"
+            command="packer build -force $on_error_option $debug_option"
             command+=" --only vsphere-iso.windows-desktop-ent"
 
             for var_file in "${var_files[@]}"; do
@@ -931,13 +945,13 @@ select_build() {
                 printf "\n\e[34m%s\e[0m\n" "$command"
             fi
 
-            eval "$command"
+            eval "$command"; build_rc=$?
             ;;
         "Professional")
             var_files=("vsphere_vars" "build_vars" "ansible_vars" "proxy_vars" "common_vars" "BUILD_VARS")
             validate_windows_username "$config_path/build.pkrvars.hcl"
             printf "Starting the build of %s %s...\n\n" "$dist" "$version"
-            command="packer build -force -on-error=ask $debug_option"
+            command="packer build -force $on_error_option $debug_option"
             command+=" --only vsphere-iso.windows-desktop-pro"
 
             for var_file in "${var_files[@]}"; do
@@ -952,7 +966,7 @@ select_build() {
                 printf "\n\e[34m%s\e[0m\n" "$command"
             fi
 
-            eval "$command"
+            eval "$command"; build_rc=$?
             ;;
         *)
             print_message error "Unsupported edition: $dist $edition"
@@ -983,6 +997,12 @@ fi
 
 # Start the script with the selecting the guest operating system.
 select_os
+
+# CI mode: exit with the build's status instead of the interactive
+# continue/quit loop (which spins forever on a closed stdin).
+if [ "$ci_mode" = true ]; then
+    exit "${build_rc:-1}"
+fi
 
 # Prompt the user to continue or quit.
 while true; do

--- a/builds/linux/ubuntu/24-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/24-04-lts/linux-ubuntu.pkr.hcl
@@ -46,13 +46,13 @@ locals {
     content_library = "${var.common_iso_content_library}/${var.iso_content_library_item}/${var.iso_file}",
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
   }
-  manifest_date   = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path   = "${path.cwd}/manifests/"
-  manifest_output = "${local.manifest_path}${local.manifest_date}.json"
-  base_name           = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
-  vm_name             = "${local.base_name}-build"
+  manifest_date        = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path        = "${path.cwd}/manifests/"
+  manifest_output      = "${local.manifest_path}${local.manifest_date}.json"
+  base_name            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
+  vm_name              = "${local.base_name}-build"
   content_library_item = local.base_name
-  ovf_export_path     = "${path.cwd}/artifacts/${local.content_library_item}"
+  ovf_export_path      = "${path.cwd}/artifacts/${local.content_library_item}"
   data_source_content = {
     "/meta-data" = file("${abspath(path.root)}/data/meta-data")
     "/user-data" = templatefile("${abspath(path.root)}/data/user-data.pkrtpl.hcl", {
@@ -80,8 +80,8 @@ locals {
   }
   data_source_command = var.common_data_source == "http" ? "ds=\"nocloud-net;seedfrom=http://{{.HTTPIP}}:{{.HTTPPort}}/\"" : "ds=\"nocloud\""
 
-  bucket_name         = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description  = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/ci/config/ansible.pkrvars.hcl
+++ b/ci/config/ansible.pkrvars.hcl
@@ -1,0 +1,10 @@
+/*
+    CI config — ansible guest account (second local account baked into the
+    template). The matching PRIVATE key lives in 1Password
+    (op://Talos/vsphere-packer/ANSIBLE_PRIVATE_KEY). Packer's ansible
+    provisioner does NOT use this key at build time — it connects as
+    build_username through Packer's SSH proxy.
+*/
+
+ansible_username = "ansible"
+ansible_key      = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMSvh5B1O5OQsu5NN9uU2AyhRwxWUUdfeEg3C6JIbV8M ansible@codelooks.com"

--- a/ci/config/ansible.pkrvars.hcl
+++ b/ci/config/ansible.pkrvars.hcl
@@ -1,9 +1,10 @@
 /*
     CI config — ansible guest account (second local account baked into the
     template). The matching PRIVATE key lives in 1Password
-    (op://Talos/vsphere-packer/ANSIBLE_PRIVATE_KEY). Packer's ansible
-    provisioner does NOT use this key at build time — it connects as
-    build_username through Packer's SSH proxy.
+    (op://Talos/vsphere-packer/ANSIBLE_PRIVATE_KEY). Packer's SSH communicator
+    connects as build_username through Packer's SSH proxy — it does NOT
+    authenticate with this key. The ansible role only writes the public key
+    into the template's authorized_keys for post-deployment access.
 */
 
 ansible_username = "ansible"

--- a/ci/config/build.pkrvars.hcl
+++ b/ci/config/build.pkrvars.hcl
@@ -1,0 +1,9 @@
+/*
+    CI config — build account.
+    build_password, build_password_encrypted and build_key come from PKR_VAR_*
+    env (1Password) — do NOT add them here (var-file would override env).
+    build_username is the single exception: build.sh's validate_linux_username
+    greps it from this file. It must match BUILD_USERNAME in 1Password.
+*/
+
+build_username = "packer"

--- a/ci/config/common.pkrvars.hcl
+++ b/ci/config/common.pkrvars.hcl
@@ -25,8 +25,9 @@ common_iso_content_library         = "Content Library"
 common_iso_content_library_enabled = false
 
 // Boot and Provisioning Settings
-common_data_source       = "disk"
-common_http_port_min     = 8000
-common_http_port_max     = 8099
-common_ip_wait_timeout   = "20m"
-common_shutdown_timeout  = "15m"
+common_data_source = "disk"
+// http ports are unused with data_source=disk but the vars have no defaults
+common_http_port_min    = 8000
+common_http_port_max    = 8099
+common_ip_wait_timeout  = "20m"
+common_shutdown_timeout = "15m"

--- a/ci/config/common.pkrvars.hcl
+++ b/ci/config/common.pkrvars.hcl
@@ -1,0 +1,32 @@
+/*
+    CI config — common build behavior. This file encodes three design decisions:
+    - common_data_source = "disk": install config delivered on a cidata CD-ROM,
+      so the runner pod needs NO inbound networking (spec decision #7).
+    - Folder-template output (common_template_conversion = true), NOT Content
+      Library output — svc-packer lacks the global permission Content Library
+      operations require (403).
+    - ISO read from a DATASTORE path, not the Content Library, for the same 403
+      reason. common_iso_content_library must still hold a value because the
+      build's locals interpolate it eagerly even when unused.
+*/
+
+// Virtual Machine Settings
+common_vm_version           = 21
+common_tools_upgrade_policy = true
+common_remove_cdrom         = true
+
+// Template and Content Library Settings
+common_template_conversion     = true
+common_content_library_enabled = false
+
+// Removable Media Settings
+common_iso_datastore               = "vsanDatastore"
+common_iso_content_library         = "Content Library"
+common_iso_content_library_enabled = false
+
+// Boot and Provisioning Settings
+common_data_source       = "disk"
+common_http_port_min     = 8000
+common_http_port_max     = 8099
+common_ip_wait_timeout   = "20m"
+common_shutdown_timeout  = "15m"

--- a/ci/config/linux-storage.pkrvars.hcl
+++ b/ci/config/linux-storage.pkrvars.hcl
@@ -1,0 +1,157 @@
+# © Broadcom. All Rights Reserved.
+# The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-2-Clause
+
+/*
+    DESCRIPTION:
+    Storage variables used for Linux builds.
+    - Variables are passed to and used by guest operating system configuration files (e.g., ks.cfg).
+*/
+
+// VM Storage Settings
+vm_disk_device   = "sda"
+vm_disk_use_swap = true
+vm_disk_partitions = [
+  {
+    name = "efi"
+    size = 1024,
+    format = {
+      label  = "EFIFS",
+      fstype = "fat32",
+    },
+    mount = {
+      path    = "/boot/efi",
+      options = "",
+    },
+    volume_group = "",
+  },
+  {
+    name = "boot"
+    size = 1024,
+    format = {
+      label  = "BOOTFS",
+      fstype = "xfs",
+    },
+    mount = {
+      path    = "/boot",
+      options = "",
+    },
+    volume_group = "",
+  },
+  {
+    name = "sysvg"
+    size = -1,
+    format = {
+      label  = "",
+      fstype = "",
+    },
+    mount = {
+      path    = "",
+      options = "",
+    },
+    volume_group = "sysvg",
+  },
+]
+vm_disk_lvm = [
+  {
+    name : "sysvg",
+    partitions : [
+      {
+        name = "lv_swap",
+        size = 1024,
+        format = {
+          label  = "SWAPFS",
+          fstype = "swap",
+        },
+        mount = {
+          path    = "",
+          options = "",
+        },
+      },
+      {
+        name = "lv_root",
+        size = 15360,
+        format = {
+          label  = "ROOTFS",
+          fstype = "xfs",
+        },
+        mount = {
+          path    = "/",
+          options = "",
+        },
+      },
+      {
+        name = "lv_home",
+        size = 4096,
+        format = {
+          label  = "HOMEFS",
+          fstype = "xfs",
+        },
+        mount = {
+          path    = "/home",
+          options = "nodev,nosuid",
+        },
+      },
+      {
+        name = "lv_opt",
+        size = 2048,
+        format = {
+          label  = "OPTFS",
+          fstype = "xfs",
+        },
+        mount = {
+          path    = "/opt",
+          options = "nodev",
+        },
+      },
+      {
+        name = "lv_tmp",
+        size = 4096,
+        format = {
+          label  = "TMPFS",
+          fstype = "xfs",
+        },
+        mount = {
+          path    = "/tmp",
+          options = "nodev,noexec,nosuid",
+        },
+      },
+      {
+        name = "lv_var",
+        size = 4096,
+        format = {
+          label  = "VARFS",
+          fstype = "xfs",
+        },
+        mount = {
+          path    = "/var",
+          options = "nodev",
+        },
+      },
+      {
+        name = "lv_log",
+        size = 4096,
+        format = {
+          label  = "LOGFS",
+          fstype = "xfs",
+        },
+        mount = {
+          path    = "/var/log",
+          options = "nodev,noexec,nosuid",
+        },
+      },
+      {
+        name = "lv_audit",
+        size = -1,
+        format = {
+          label  = "AUDITFS",
+          fstype = "xfs",
+        },
+        mount = {
+          path    = "/var/log/audit",
+          options = "nodev,noexec,nosuid",
+        },
+      },
+    ],
+  }
+]

--- a/ci/config/linux-ubuntu-24-04-lts.pkrvars.hcl
+++ b/ci/config/linux-ubuntu-24-04-lts.pkrvars.hcl
@@ -1,0 +1,22 @@
+/*
+    CI config — Ubuntu Server 24.04 LTS build.
+    iso_datastore_path + iso_file must match the object uploaded to
+    vsanDatastore (see the ISO staging step in the Plan 2 runbook).
+    iso_content_library_item is unused (CL disabled) but must hold a value —
+    the build's locals interpolate it eagerly.
+*/
+
+// Guest Operating System Metadata
+vm_guest_os_name    = "ubuntu"
+vm_guest_os_version = "24.04-lts"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "ubuntu64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware = "efi-secure"
+
+// Removable Media Settings
+iso_datastore_path       = "iso/linux/ubuntu-server/24-04-lts/amd64"
+iso_content_library_item = "ubuntu-24.04.3-live-server-amd64"
+iso_file                 = "ubuntu-24.04.3-live-server-amd64.iso"

--- a/ci/config/network.pkrvars.hcl
+++ b/ci/config/network.pkrvars.hcl
@@ -1,0 +1,16 @@
+# © Broadcom. All Rights Reserved.
+# The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-2-Clause
+
+/*
+    DESCRIPTION:
+    Network variables used for all builds.
+    - Variables are passed to and used by guest operating system configuration files (e.g., ks.cfg).
+
+*/
+
+// VM Network Settings (default DHCP)
+// vm_ip_address = "172.16.100.192"
+// vm_ip_netmask = 24
+// vm_ip_gateway = "172.16.100.1"
+// vm_dns_list   = [ "172.16.11.4", "172.16.11.5" ]

--- a/ci/config/proxy.pkrvars.hcl
+++ b/ci/config/proxy.pkrvars.hcl
@@ -1,0 +1,15 @@
+# © Broadcom. All Rights Reserved.
+# The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-2-Clause
+
+/*
+    DESCRIPTION:
+    Proxy variables used for Linux builds. (Optional)
+    - Variables are passed to and used by configuration scripts.
+*/
+
+// Proxy Credentials
+// communicator_proxy_host     = "proxy.example.com"
+// communicator_proxy_port     = 8080
+// communicator_proxy_username = "packer"
+// communicator_proxy_password = "_P@cker_Ex#mple$_"

--- a/ci/config/vsphere.pkrvars.hcl
+++ b/ci/config/vsphere.pkrvars.hcl
@@ -1,0 +1,11 @@
+/*
+    CI config — vSphere.
+    INTENTIONALLY contains no credentials or placement values: vsphere_endpoint,
+    vsphere_username, vsphere_password, vsphere_insecure_connection,
+    vsphere_datacenter, vsphere_cluster, vsphere_datastore, vsphere_network and
+    vsphere_folder all arrive as PKR_VAR_* env from 1Password (External Secrets
+    on the runner pod). A key present here would silently override that env —
+    Packer precedence puts -var-file ABOVE environment variables. Do not add keys.
+*/
+
+vsphere_set_host_for_datastore_uploads = false


### PR DESCRIPTION
## Summary

Plan 2 thin slice: everything needed to build one Ubuntu Server 24.04 template end-to-end on the in-cluster `packer-vsphere` ARC runner.

- **`ci/config/`** — tracked, credential-free var-file set (8 files). Credentials and placement come exclusively from `PKR_VAR_*` env (1Password → External Secrets); only `build_username = "packer"` is in-file because `build.sh` greps for it. Sidesteps the var-file-beats-env precedence trap.
- **`build.sh --ci`** — non-interactive mode: auto-continue, `-on-error=cleanup`, real exit-code propagation, and an abort (instead of an infinite menu recursion) on a missing build dir.
- **`validate.yml`** — PR gate on GitHub-hosted runners: `packer fmt -check` + `packer init` + `packer validate` with the full 8-var-file stack under dummy creds.
- **`build-templates.yml`** — dispatch-only, runs on the self-hosted `packer-vsphere` label. Manifest artifact always (colon-stamped names renamed for upload-artifact v4); `PACKER_LOG=1` debug log uploaded **only on failure and only after secret scrubbing** (gated on scrub success — PACKER_LOG plugin traces bypass Packer's sensitive-var masking).
- **`.gitignore`** — `config/` anchored to `/config/` so the machine-local config dir stays ignored without swallowing `ci/config/`.
- **lint** — vendored upstream shell scripts excluded from super-linter.

## Security posture (public repo, self-hosted runner)

- Build workflow is `workflow_dispatch` only — no PR-triggered path to the self-hosted runner.
- `pull_request` (never `pull_request_target`) for the GitHub-hosted validate gate; dummy creds only.
- All actions SHA-pinned; `persist-credentials: false` everywhere.
- Debug-log artifact is failure-only and scrubbed of every sensitive `PKR_VAR_*` value before upload.

## Test plan

- [x] `packer validate` green locally with the dummy env validate.yml uses
- [x] `bash -n build.sh`; `--ci` flag verified (exit-code propagation, missing-dir abort)
- [x] actionlint + super-linter local pass; leak-check grep over tracked files
- [ ] CI checks on this PR (lint, validate, Checkov, Trivy)
- [ ] Post-merge: dispatch `build-templates` → template `linux-ubuntu-24.04-lts-*` in vCenter (Plan 2 Task 12)