### PR TITLE
fix(ci): keep build_username literal out of var-file comments

### DIFF
--- a/ci/config/build.pkrvars.hcl
+++ b/ci/config/build.pkrvars.hcl
@@ -2,8 +2,11 @@
     CI config — build account.
     build_password, build_password_encrypted and build_key come from PKR_VAR_*
     env (1Password) — do NOT add them here (var-file would override env).
-    build_username is the single exception: build.sh's validate_linux_username
-    greps it from this file. It must match BUILD_USERNAME in 1Password.
+    The username below is the single exception: build.sh greps this file for
+    it with an UNANCHORED pattern, so the literal variable name must not
+    appear anywhere but the assignment line (a comment mention makes the
+    extracted value multi-line and fails validation). It must match
+    BUILD_USERNAME in 1Password.
 */
 
 build_username = "packer"


### PR DESCRIPTION
First `build-templates` dispatch (run 27271661796) failed in seconds: `Build username \npacker is invalid for Linux OS`.

**Root cause:** `build.sh` extracts the username with an unanchored `grep 'build_username' | awk -F '\"' '{print $2}'`. The header comment in `ci/config/build.pkrvars.hcl` mentioned the variable name, matched the grep, contributed an empty awk field, and the extracted value became `"\npacker"` — failing `validate_linux_username`.

**Fix:** reword the comment so the literal variable name appears only on the assignment line, and document the trap so it doesn't get reintroduced.

**Verified locally:** reproduced build.sh's exact grep|awk + regex against the fixed file → extracts `packer`, passes; `packer fmt -check` clean.