### PR TITLE
fix(ubuntu): match any en* interface in autoinstall netplan

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,6 @@ jobs:
       # build.sh/download.sh/config.sh/set-envvars.sh are vendored from
       # upstream vmware/packer-examples-for-vsphere — not house style; we
       # carry minimal surgical diffs and re-merge upstream periodically.
-      filter-regex-exclude: '(^|/)(vendor|node_modules|\.terraform|\.venv|dist|build)/|.*\.tmpl$|(^|/)(build|download|config|set-envvars)\.sh$'
+      # *.pkrtpl.hcl are Packer templatefile() inputs (%{ ~} directives),
+      # not Terragrunt HCL — terragrunt hclfmt cannot parse them.
+      filter-regex-exclude: '(^|/)(vendor|node_modules|\.terraform|\.venv|dist|build)/|.*\.tmpl$|.*\.pkrtpl\.hcl$|(^|/)(build|download|config|set-envvars)\.sh$'

--- a/builds/linux/ubuntu/24-04-lts/data/network.pkrtpl.hcl
+++ b/builds/linux/ubuntu/24-04-lts/data/network.pkrtpl.hcl
@@ -16,6 +16,12 @@
               - ${item}
 %{ endfor ~}
 %{ else ~}
+        # ${device} is a netplan ID here, not an interface name: the guest's
+        # predictable name follows the virtual hardware's PCI slot (observed
+        # ens33 via ethernet0.pciSlotNumber = 33, not the ens192 default), so
+        # match any en* interface instead of pinning a name.
         ${device}:
+          match:
+            name: en*
           dhcp4: true
 %{ endif ~}


### PR DESCRIPTION
Four `build-templates` runs failed with `timeout waiting for IP address`. Instrumented triage (guest-state polling + OPNsense dnsmasq logs) pinned it down:

1. Boot command works; the live installer runs with open-vm-tools active ~1 min after power-on.
2. casper's early DHCP gets a lease — dnsmasq logs a full DISCOVER→ACK for the build VM's MAC.
3. The VM's NIC sits at **PCI slot 33** (`ethernet0.pciSlotNumber = 33`), so the guest's predictable name is **ens33** — not the **ens192** the netplan template pins.
4. When subiquity applies the autoinstall netplan it matches no interface: `guest.net` goes empty (even link-local drops) and Packer's 20-minute IP wait expires.

**Fix:** in the DHCP branch of `network.pkrtpl.hcl`, keep `${device}` as the netplan ID but add `match: {name: en*}` so any predictable-named interface gets DHCP, regardless of slot assignment. The static-IP branch is untouched (unused by the thin slice).

**Verified locally:** `packer validate` green with the CI dummy env and the full 8 var-file stack.