### PR TITLE
feat(build): ubuntu 22.04 LTS line

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -15,6 +15,7 @@ on:
         options:
           - all
           - ubuntu-2404
+          - ubuntu-2204
 
 permissions:
   contents: read

--- a/.github/workflows/upload-isos.yml
+++ b/.github/workflows/upload-isos.yml
@@ -18,6 +18,7 @@ on: # checkov:skip=CKV_GHA_7: fixed-set choice input; not a free-text injection 
         options:
           - all
           - ubuntu-2404
+          - ubuntu-2204
 
 permissions:
   contents: read

--- a/builds/linux/ubuntu/22-04-lts/data/network.pkrtpl.hcl
+++ b/builds/linux/ubuntu/22-04-lts/data/network.pkrtpl.hcl
@@ -16,6 +16,12 @@
               - ${item}
 %{ endfor ~}
 %{ else ~}
+        # ${device} is a netplan ID here, not an interface name: the guest's
+        # predictable name follows the virtual hardware's PCI slot (observed
+        # ens33 via ethernet0.pciSlotNumber = 33, not the ens192 default), so
+        # match any en* interface instead of pinning a name.
         ${device}:
+          match:
+            name: en*
           dhcp4: true
 %{ endif ~}

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
@@ -46,13 +46,13 @@ locals {
     content_library = "${var.common_iso_content_library}/${var.iso_content_library_item}/${var.iso_file}",
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
   }
-  manifest_date   = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path   = "${path.cwd}/manifests/"
-  manifest_output = "${local.manifest_path}${local.manifest_date}.json"
-  base_name           = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
-  vm_name             = "${local.base_name}-build"
+  manifest_date        = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path        = "${path.cwd}/manifests/"
+  manifest_output      = "${local.manifest_path}${local.manifest_date}.json"
+  base_name            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
+  vm_name              = "${local.base_name}-build"
   content_library_item = local.base_name
-  ovf_export_path     = "${path.cwd}/artifacts/${local.content_library_item}"
+  ovf_export_path      = "${path.cwd}/artifacts/${local.content_library_item}"
   data_source_content = {
     "/meta-data" = file("${abspath(path.root)}/data/meta-data")
     "/user-data" = templatefile("${abspath(path.root)}/data/user-data.pkrtpl.hcl", {

--- a/ci/config/linux-ubuntu-22-04-lts.pkrvars.hcl
+++ b/ci/config/linux-ubuntu-22-04-lts.pkrvars.hcl
@@ -1,0 +1,21 @@
+/*
+    CI config — Ubuntu Server 22.04 LTS build.
+    iso_datastore_path + iso_file must match the object staged by the
+    upload-isos workflow. iso_content_library_item is unused (CL disabled)
+    but must hold a value — the build's locals interpolate it eagerly.
+*/
+
+// Guest Operating System Metadata
+vm_guest_os_name    = "ubuntu"
+vm_guest_os_version = "22.04-lts"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "ubuntu64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware = "efi-secure"
+
+// Removable Media Settings
+iso_datastore_path       = "iso/linux/ubuntu-server/22-04-lts/amd64"
+iso_content_library_item = "ubuntu-22.04.5-live-server-amd64"
+iso_file                 = "ubuntu-22.04.5-live-server-amd64.iso"

--- a/ci/matrix.json
+++ b/ci/matrix.json
@@ -15,5 +15,22 @@
       "type": "sums-regex",
       "pattern": "ubuntu-24\\.04\\.(\\d+)-live-server-amd64\\.iso"
     }
+  },
+  {
+    "key": "ubuntu-2204",
+    "enabled": true,
+    "os": "Linux",
+    "dist": "Ubuntu Server",
+    "version": "22.04",
+    "build_dir": "builds/linux/ubuntu/22-04-lts",
+    "config": "linux-ubuntu-22-04-lts.pkrvars.hcl",
+    "base_name": "linux-ubuntu-22.04-lts-main",
+    "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.5-live-server-amd64.iso",
+    "sums_url": "https://releases.ubuntu.com/22.04/SHA256SUMS",
+    "iso_datastore_path": "iso/linux/ubuntu-server/22-04-lts/amd64",
+    "discover": {
+      "type": "sums-regex",
+      "pattern": "ubuntu-22\\.04\\.(\\d+)-live-server-amd64\\.iso"
+    }
   }
 ]


### PR DESCRIPTION
Plan 3 Task 5. Applies the proven netplan match:en* fix (NIC at PCI slot 33 -> ens33). Produces Templates/linux-ubuntu-22.04-lts-main, the name terraform-vsphere already targets.

Also includes a `packer fmt` fix for `builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl` (pre-existing local alignment gap that would fail the fmt -check gate in validate.yml).