### PR TITLE
feat(build): Debian 12 line

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -16,6 +16,7 @@ on:
           - all
           - ubuntu-2404
           - ubuntu-2204
+          - debian-12
 
 permissions:
   contents: read

--- a/.github/workflows/upload-isos.yml
+++ b/.github/workflows/upload-isos.yml
@@ -19,6 +19,7 @@ on: # checkov:skip=CKV_GHA_7: fixed-set choice input; not a free-text injection 
           - all
           - ubuntu-2404
           - ubuntu-2204
+          - debian-12
 
 permissions:
   contents: read

--- a/builds/linux/debian/12/linux-debian.pkr.hcl
+++ b/builds/linux/debian/12/linux-debian.pkr.hcl
@@ -46,13 +46,13 @@ locals {
     content_library = "${var.common_iso_content_library}/${var.iso_content_library_item}/${var.iso_file}",
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
   }
-  manifest_date   = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path   = "${path.cwd}/manifests/"
-  manifest_output = "${local.manifest_path}${local.manifest_date}.json"
-  base_name           = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
-  vm_name             = "${local.base_name}-build"
+  manifest_date        = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path        = "${path.cwd}/manifests/"
+  manifest_output      = "${local.manifest_path}${local.manifest_date}.json"
+  base_name            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
+  vm_name              = "${local.base_name}-build"
   content_library_item = local.base_name
-  ovf_export_path     = "${path.cwd}/artifacts/${local.content_library_item}"
+  ovf_export_path      = "${path.cwd}/artifacts/${local.content_library_item}"
   data_source_content = {
     "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", {
       build_username           = var.build_username
@@ -83,8 +83,8 @@ locals {
   mount_cdrom_command = "<leftAltOn><f2><leftAltOff> <enter><wait> mount /dev/sr1 /media<enter> <leftAltOn><f1><leftAltOff>"
   mount_cdrom         = var.common_data_source == "http" ? " " : local.mount_cdrom_command
 
-  bucket_name         = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description  = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/ci/config/linux-debian-12.pkrvars.hcl
+++ b/ci/config/linux-debian-12.pkrvars.hcl
@@ -1,0 +1,27 @@
+/*
+    CI config — Debian 12 (Bookworm) build.
+    vm_guest_os_version is pinned to the major version: it feeds the
+    template name (linux-debian-12-main), which must stay stable across
+    point releases for Terraform consumers.
+    vm_network_device feeds preseed netcfg/choose_interface: "auto" makes
+    the installer pick the live NIC (ens33 in this vCenter — PCI slot 33 —
+    not the engine-default ens192).
+*/
+
+// Guest Operating System Metadata
+vm_guest_os_name    = "debian"
+vm_guest_os_version = "12"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "debian12_64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware = "efi-secure"
+
+// Network Settings
+vm_network_device = "auto"
+
+// Removable Media Settings
+iso_datastore_path       = "iso/linux/debian/12/amd64"
+iso_content_library_item = "debian-12.13.0-amd64-netinst"
+iso_file                 = "debian-12.13.0-amd64-netinst.iso"

--- a/ci/matrix.json
+++ b/ci/matrix.json
@@ -32,5 +32,25 @@
       "type": "sums-regex",
       "pattern": "ubuntu-22\\.04\\.(\\d+)-live-server-amd64\\.iso"
     }
+  },
+  {
+    "key": "debian-12",
+    "enabled": true,
+    "os": "Linux",
+    "dist": "Debian",
+    "version": "12",
+    "build_dir": "builds/linux/debian/12",
+    "config": "linux-debian-12.pkrvars.hcl",
+    "base_name": "linux-debian-12-main",
+    "iso_url": "https://cdimage.debian.org/cdimage/archive/12.13.0/amd64/iso-cd/debian-12.13.0-amd64-netinst.iso",
+    "sums_url": "https://cdimage.debian.org/cdimage/archive/12.13.0/amd64/iso-cd/SHA256SUMS",
+    "iso_datastore_path": "iso/linux/debian/12/amd64",
+    "discover": {
+      "type": "dir-listing",
+      "listing_url": "https://cdimage.debian.org/cdimage/archive/",
+      "dir_pattern": "href=\"(12\\.[0-9]+\\.[0-9]+)/\"",
+      "url_template": "https://cdimage.debian.org/cdimage/archive/{ver}/amd64/iso-cd/debian-{ver}-amd64-netinst.iso",
+      "sums_template": "https://cdimage.debian.org/cdimage/archive/{ver}/amd64/iso-cd/SHA256SUMS"
+    }
   }
 ]


### PR DESCRIPTION
Plan 3 Task 6. vm_network_device=auto sidesteps the ens192/ens33 trap via preseed choose_interface; major-pinned version keeps the template name stable (linux-debian-12-main).