### PR TITLE
feat(build): Debian 13 line

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -17,6 +17,7 @@ on:
           - ubuntu-2404
           - ubuntu-2204
           - debian-12
+          - debian-13
 
 permissions:
   contents: read

--- a/.github/workflows/upload-isos.yml
+++ b/.github/workflows/upload-isos.yml
@@ -20,6 +20,7 @@ on: # checkov:skip=CKV_GHA_7: fixed-set choice input; not a free-text injection 
           - ubuntu-2404
           - ubuntu-2204
           - debian-12
+          - debian-13
 
 permissions:
   contents: read

--- a/ci/config/linux-debian-13.pkrvars.hcl
+++ b/ci/config/linux-debian-13.pkrvars.hcl
@@ -1,0 +1,25 @@
+/*
+    CI config — Debian 13 (Trixie) build.
+    vm_guest_os_version pinned to the major version for a stable template
+    name (linux-debian-13-main). vm_network_device=auto: see debian 12.
+    vm_guest_os_type per upstream example: vSphere has no debian13 guest id
+    at vm_version 21, so other6xLinux64Guest.
+*/
+
+// Guest Operating System Metadata
+vm_guest_os_name    = "debian"
+vm_guest_os_version = "13"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "other6xLinux64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware = "efi-secure"
+
+// Network Settings
+vm_network_device = "auto"
+
+// Removable Media Settings
+iso_datastore_path       = "iso/linux/debian/13/amd64"
+iso_content_library_item = "debian-13.5.0-amd64-netinst"
+iso_file                 = "debian-13.5.0-amd64-netinst.iso"

--- a/ci/matrix.json
+++ b/ci/matrix.json
@@ -52,5 +52,25 @@
       "url_template": "https://cdimage.debian.org/cdimage/archive/{ver}/amd64/iso-cd/debian-{ver}-amd64-netinst.iso",
       "sums_template": "https://cdimage.debian.org/cdimage/archive/{ver}/amd64/iso-cd/SHA256SUMS"
     }
+  },
+  {
+    "key": "debian-13",
+    "enabled": true,
+    "os": "Linux",
+    "dist": "Debian",
+    "version": "13",
+    "build_dir": "builds/linux/debian/13",
+    "config": "linux-debian-13.pkrvars.hcl",
+    "base_name": "linux-debian-13-main",
+    "iso_url": "https://cdimage.debian.org/cdimage/release/13.5.0/amd64/iso-cd/debian-13.5.0-amd64-netinst.iso",
+    "sums_url": "https://cdimage.debian.org/cdimage/release/13.5.0/amd64/iso-cd/SHA256SUMS",
+    "iso_datastore_path": "iso/linux/debian/13/amd64",
+    "discover": {
+      "type": "dir-listing",
+      "listing_url": "https://cdimage.debian.org/cdimage/release/",
+      "dir_pattern": "href=\"(13\\.[0-9]+\\.[0-9]+)/\"",
+      "url_template": "https://cdimage.debian.org/cdimage/release/{ver}/amd64/iso-cd/debian-{ver}-amd64-netinst.iso",
+      "sums_template": "https://cdimage.debian.org/cdimage/release/{ver}/amd64/iso-cd/SHA256SUMS"
+    }
   }
 ]


### PR DESCRIPTION
Plan 3 Task 7. Same choose_interface=auto pattern as debian 12; release/ URLs (current stable) vs 12's archive/. Produces Templates/linux-debian-13-main.

**ISO version note:** 13.3.0 was 404 — current stable is 13.5.0; all references in `ci/config/linux-debian-13.pkrvars.hcl` and `ci/matrix.json` consistently use 13.5.0.

**When Debian 14 ships and 13 moves to archive:** the `discover.listing_url` in matrix.json for debian-13 will need flipping from `release/` to `archive/` — `check-iso-updates` will fail loudly at that point as the designed signal.

## Changes
- `ci/config/linux-debian-13.pkrvars.hcl` — new CI config; `vm_guest_os_type=other6xLinux64Guest` (no debian13 guest ID at vm_version 21), `vm_network_device=auto`, EFI-secure firmware
- `ci/matrix.json` — debian-13 entry with `release/` dir-listing discover
- `.github/workflows/build-templates.yml` — `- debian-13` dispatch option
- `.github/workflows/upload-isos.yml` — `- debian-13` dispatch option

## Validation
- `packer fmt -check`: clean (no whitespace fixes needed, unlike debian 12)
- `packer validate`: passed with local config + ci/config/linux-debian-13.pkrvars.hcl
- `jq .` matrix.json: valid JSON
- YAML check both workflows: valid