### PR TITLE
feat(build): Rocky Linux 9 line

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -18,6 +18,7 @@ on:
           - ubuntu-2204
           - debian-12
           - debian-13
+          - rocky-9
 
 permissions:
   contents: read

--- a/.github/workflows/upload-isos.yml
+++ b/.github/workflows/upload-isos.yml
@@ -21,6 +21,7 @@ on: # checkov:skip=CKV_GHA_7: fixed-set choice input; not a free-text injection 
           - ubuntu-2204
           - debian-12
           - debian-13
+          - rocky-9
 
 permissions:
   contents: read

--- a/builds/linux/rocky/9/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/9/linux-rocky.pkr.hcl
@@ -46,13 +46,13 @@ locals {
     content_library = "${var.common_iso_content_library}/${var.iso_content_library_item}/${var.iso_file}",
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
   }
-  manifest_date   = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path   = "${path.cwd}/manifests/"
-  manifest_output = "${local.manifest_path}${local.manifest_date}.json"
-  base_name           = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
-  vm_name             = "${local.base_name}-build"
+  manifest_date        = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path        = "${path.cwd}/manifests/"
+  manifest_output      = "${local.manifest_path}${local.manifest_date}.json"
+  base_name            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
+  vm_name              = "${local.base_name}-build"
   content_library_item = local.base_name
-  ovf_export_path     = "${path.cwd}/artifacts/${local.content_library_item}"
+  ovf_export_path      = "${path.cwd}/artifacts/${local.content_library_item}"
   data_source_content = {
     "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", {
       build_username           = var.build_username
@@ -80,8 +80,8 @@ locals {
   }
   data_source_command = var.common_data_source == "http" ? "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "inst.ks=cdrom:/ks.cfg"
 
-  bucket_name         = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description  = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/ci/config/linux-rocky-9.pkrvars.hcl
+++ b/ci/config/linux-rocky-9.pkrvars.hcl
@@ -1,0 +1,26 @@
+/*
+    CI config — Rocky Linux 9 build.
+    vm_guest_os_version pinned to the major version for a stable template
+    name (linux-rocky-9-main). vm_network_device feeds kickstart's
+    'network --device=': "link" selects the first NIC with link up (the
+    guest names ours ens33 — PCI slot 33 — not the engine-default ens192).
+    vm_firmware "efi" (not efi-secure) per the upstream example.
+*/
+
+// Guest Operating System Metadata
+vm_guest_os_name    = "rocky"
+vm_guest_os_version = "9"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "rockylinux_64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware = "efi"
+
+// Network Settings
+vm_network_device = "link"
+
+// Removable Media Settings
+iso_datastore_path       = "iso/linux/rocky-linux/9/amd64"
+iso_content_library_item = "Rocky-9.8-x86_64-dvd"
+iso_file                 = "Rocky-9.8-x86_64-dvd.iso"

--- a/ci/matrix.json
+++ b/ci/matrix.json
@@ -72,5 +72,25 @@
       "url_template": "https://cdimage.debian.org/cdimage/release/{ver}/amd64/iso-cd/debian-{ver}-amd64-netinst.iso",
       "sums_template": "https://cdimage.debian.org/cdimage/release/{ver}/amd64/iso-cd/SHA256SUMS"
     }
+  },
+  {
+    "key": "rocky-9",
+    "enabled": true,
+    "os": "Linux",
+    "dist": "Rocky Linux",
+    "version": "9",
+    "build_dir": "builds/linux/rocky/9",
+    "config": "linux-rocky-9.pkrvars.hcl",
+    "base_name": "linux-rocky-9-main",
+    "iso_url": "https://download.rockylinux.org/pub/rocky/9.8/isos/x86_64/Rocky-9.8-x86_64-dvd.iso",
+    "sums_url": "https://download.rockylinux.org/pub/rocky/9.8/isos/x86_64/CHECKSUM",
+    "iso_datastore_path": "iso/linux/rocky-linux/9/amd64",
+    "discover": {
+      "type": "dir-listing",
+      "listing_url": "https://download.rockylinux.org/pub/rocky/",
+      "dir_pattern": "href=\"(9\\.[0-9]+)/\"",
+      "url_template": "https://download.rockylinux.org/pub/rocky/{ver}/isos/x86_64/Rocky-{ver}-x86_64-dvd.iso",
+      "sums_template": "https://download.rockylinux.org/pub/rocky/{ver}/isos/x86_64/CHECKSUM"
+    }
   }
 ]


### PR DESCRIPTION
Plan 3 Task 8. First kickstart-family line: vm_network_device=link (first NIC with link up) sidesteps the ens192/ens33 trap. dvd ISO ~15GB — stage solo. Produces Templates/linux-rocky-9-main.