### PR TITLE
feat(build): AlmaLinux 9 line

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -19,6 +19,7 @@ on:
           - debian-12
           - debian-13
           - rocky-9
+          - almalinux-9
 
 permissions:
   contents: read

--- a/.github/workflows/upload-isos.yml
+++ b/.github/workflows/upload-isos.yml
@@ -22,6 +22,7 @@ on: # checkov:skip=CKV_GHA_7: fixed-set choice input; not a free-text injection 
           - debian-12
           - debian-13
           - rocky-9
+          - almalinux-9
 
 permissions:
   contents: read

--- a/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
@@ -45,13 +45,13 @@ locals {
     content_library = "${var.common_iso_content_library}/${var.iso_content_library_item}/${var.iso_file}",
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
   }
-  manifest_date   = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path   = "${path.cwd}/manifests/"
-  manifest_output = "${local.manifest_path}${local.manifest_date}.json"
-  base_name           = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
-  vm_name             = "${local.base_name}-build"
+  manifest_date        = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path        = "${path.cwd}/manifests/"
+  manifest_output      = "${local.manifest_path}${local.manifest_date}.json"
+  base_name            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
+  vm_name              = "${local.base_name}-build"
   content_library_item = local.base_name
-  ovf_export_path     = "${path.cwd}/artifacts/${local.content_library_item}"
+  ovf_export_path      = "${path.cwd}/artifacts/${local.content_library_item}"
   data_source_content = {
     "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", {
       build_username           = var.build_username
@@ -79,8 +79,8 @@ locals {
   }
   data_source_command = var.common_data_source == "http" ? "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "inst.ks=cdrom:/ks.cfg"
 
-  bucket_name         = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description  = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/ci/config/linux-almalinux-9.pkrvars.hcl
+++ b/ci/config/linux-almalinux-9.pkrvars.hcl
@@ -1,0 +1,23 @@
+/*
+    CI config — AlmaLinux OS 9 build.
+    vm_guest_os_version pinned to the major version for a stable template
+    name (linux-almalinux-9-main). vm_network_device=link: see rocky 9.
+*/
+
+// Guest Operating System Metadata
+vm_guest_os_name    = "almalinux"
+vm_guest_os_version = "9"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "almalinux_64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware = "efi-secure"
+
+// Network Settings
+vm_network_device = "link"
+
+// Removable Media Settings
+iso_datastore_path       = "iso/linux/almalinux-os/9/amd64"
+iso_content_library_item = "AlmaLinux-9.8-x86_64-dvd"
+iso_file                 = "AlmaLinux-9.8-x86_64-dvd.iso"

--- a/ci/matrix.json
+++ b/ci/matrix.json
@@ -92,5 +92,25 @@
       "url_template": "https://download.rockylinux.org/pub/rocky/{ver}/isos/x86_64/Rocky-{ver}-x86_64-dvd.iso",
       "sums_template": "https://download.rockylinux.org/pub/rocky/{ver}/isos/x86_64/CHECKSUM"
     }
+  },
+  {
+    "key": "almalinux-9",
+    "enabled": true,
+    "os": "Linux",
+    "dist": "AlmaLinux OS",
+    "version": "9",
+    "build_dir": "builds/linux/almalinux/9",
+    "config": "linux-almalinux-9.pkrvars.hcl",
+    "base_name": "linux-almalinux-9-main",
+    "iso_url": "https://repo.almalinux.org/almalinux/9.8/isos/x86_64/AlmaLinux-9.8-x86_64-dvd.iso",
+    "sums_url": "https://repo.almalinux.org/almalinux/9.8/isos/x86_64/CHECKSUM",
+    "iso_datastore_path": "iso/linux/almalinux-os/9/amd64",
+    "discover": {
+      "type": "dir-listing",
+      "listing_url": "https://repo.almalinux.org/almalinux/",
+      "dir_pattern": "href=\"(9\\.[0-9]+)/\"",
+      "url_template": "https://repo.almalinux.org/almalinux/{ver}/isos/x86_64/AlmaLinux-{ver}-x86_64-dvd.iso",
+      "sums_template": "https://repo.almalinux.org/almalinux/{ver}/isos/x86_64/CHECKSUM"
+    }
   }
 ]


### PR DESCRIPTION
Plan 3 Task 9. Last Linux line: same kickstart device=link pattern as rocky 9. dvd ISO ~15GB — stage solo. Produces Templates/linux-almalinux-9-main.

- CI config: `efi-secure` firmware (upstream example), `vm_guest_os_version=9` for stable template name, `vm_network_device=link`
- ISO pinned to 9.8 (live-verified: HTTP 200, SHA256 confirmed)
- matrix.json entry with dir-listing discover block
- `almalinux-9` added to dispatch options in build-templates.yml and upload-isos.yml
- Pre-existing whitespace fmt fix in linux-almalinux.pkr.hcl included
- `packer validate` passes locally with dummy creds