### PR TITLE
fix(build): debian 13 — trixie preseed hang + -build naming

### DIFF
--- a/builds/linux/debian/13/data/ks.pkrtpl.hcl
+++ b/builds/linux/debian/13/data/ks.pkrtpl.hcl
@@ -47,7 +47,12 @@ d-i preseed/late_command string \
     in-target chmod 440 /etc/sudoers.d/${build_username} ;
 
 %{ if common_data_source == "disk" ~}
-# Umount preseed media early
+# Free and drop the preseed CD (sr1) so later install steps only see the
+# OS media. Best-effort on purpose: on trixie, a strict '&&' chain here
+# exits 1 and d-i raises a BLOCKING "Failed to run preseeded command"
+# dialog (observed via console screenshot) — the install then hangs
+# forever. -l (lazy) handles a busy mount; common_remove_cdrom detaches
+# the CDs at the end of the build regardless.
 d-i preseed/early_command string \
-    umount /media && echo 1 > /sys/block/sr1/device/delete ;
+    umount -l /media || true ; echo 1 > /sys/block/sr1/device/delete || true
 %{ endif ~}

--- a/builds/linux/debian/13/linux-debian.pkr.hcl
+++ b/builds/linux/debian/13/linux-debian.pkr.hcl
@@ -46,10 +46,13 @@ locals {
     content_library = "${var.common_iso_content_library}/${var.iso_content_library_item}/${var.iso_file}",
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
   }
-  manifest_date   = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path   = "${path.cwd}/manifests/"
-  manifest_output = "${local.manifest_path}${local.manifest_date}.json"
-  ovf_export_path = "${path.cwd}/artifacts/${local.vm_name}"
+  manifest_date        = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path        = "${path.cwd}/manifests/"
+  manifest_output      = "${local.manifest_path}${local.manifest_date}.json"
+  base_name            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
+  vm_name              = "${local.base_name}-build"
+  content_library_item = local.base_name
+  ovf_export_path      = "${path.cwd}/artifacts/${local.content_library_item}"
   data_source_content = {
     "/ks.cfg" = templatefile("${abspath(path.root)}/data/ks.pkrtpl.hcl", {
       build_username           = var.build_username
@@ -79,9 +82,9 @@ locals {
   data_source_command = var.common_data_source == "http" ? "url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "file=/media/ks.cfg"
   mount_cdrom_command = "<leftAltOn><f2><leftAltOff> <enter><wait> mount /dev/sr1 /media<enter> <leftAltOn><f1><leftAltOff>"
   mount_cdrom         = var.common_data_source == "http" ? " " : local.mount_cdrom_command
-  vm_name             = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
-  bucket_name         = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description  = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+
+  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source
@@ -189,6 +192,7 @@ source "vsphere-iso" "linux-debian" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_enabled ? [1] : []
     content {
+      name        = local.content_library_item
       library     = var.common_content_library
       description = local.build_description
       ovf         = var.common_content_library_ovf
@@ -201,7 +205,7 @@ source "vsphere-iso" "linux-debian" {
   dynamic "export" {
     for_each = var.common_ovf_export_enabled ? [1] : []
     content {
-      name        = local.vm_name
+      name        = local.content_library_item
       force       = var.common_ovf_export_overwrite
       image_files = var.common_ovf_export_image_files
       options = [


### PR DESCRIPTION
## Summary

- **Bug 1 — preseed hang:** `umount /media && echo 1 > /sys/block/sr1/device/delete` exits 1 on trixie (bookworm ignores the error). d-i raises a blocking `"Failed to run preseeded command"` dialog that halts the unattended install indefinitely (confirmed via console screenshot). Changed to `umount -l /media || true ; echo 1 > /sys/block/sr1/device/delete || true` — best-effort, idempotent with `common_remove_cdrom`.
- **Bug 2 — missing `-build` suffix:** The upstream debian/13 dir was added with a refactored `vm_name` that drops the `-build` suffix and loses `base_name`/`content_library_item`. Every other build dir (including debian/12) names the live build VM `<base>-build` and the content-library/OVF artifact `<base>`, which is what the CI promote-swap step expects. Realigned debian/13 locals and `name` attributes to exactly match debian/12's structure.

## Verification

- `packer validate` passes (dummy env credentials).
- `packer fmt -check -recursive builds/linux/debian/13` exits clean.
- `diff debian/12 debian/13` shows **only** the `"Debian 12"` / `"Debian 13"` description comment line.

## Test plan

- [ ] Trigger `build-templates` workflow targeting `linux-debian-13` and confirm the build VM is named `linux-debian-13-<sha>-build`, the template is renamed to `linux-debian-13-<sha>`, and `config.template=true` via govc.