### PR TITLE
fix(ci): upload-isos timeout 120 -> 300 min

### DIFF
--- a/.github/workflows/upload-isos.yml
+++ b/.github/workflows/upload-isos.yml
@@ -34,7 +34,10 @@ concurrency:
 jobs:
   upload:
     runs-on: packer-vsphere
-    timeout-minutes: 120
+    # EL dvd ISOs are ~15 GB; slow mirrors run ~2 MB/s — the rocky-9 staging
+    # was killed at 2h mid-download. Budget generously; the job is mostly
+    # idle network wait and the work volume holds only one ISO at a time.
+    timeout-minutes: 300
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
rocky-9 staging was killed by the 2h job timeout mid-download (15.2 GB dvd, slow mirror). Atomic .partial upload meant no corruption; this just budgets realistically.