### PR TITLE
feat(ci): weekly schedules

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -6,6 +6,10 @@ name: build-templates
 # only run from main.
 # (the dispatch 'options' list below must be kept in sync by hand — GitHub cannot populate choice inputs dynamically).
 on:
+  schedule:
+    # Weekly rebuild, Saturday 02:00 UTC — all enabled lines (the plan job
+    # defaults to 'all' when there is no dispatch input).
+    - cron: "0 2 * * 6"
   workflow_dispatch:
     inputs:
       os:

--- a/.github/workflows/check-iso-updates.yml
+++ b/.github/workflows/check-iso-updates.yml
@@ -10,6 +10,9 @@ name: check-iso-updates
 # trigger PR-check workflows — close and reopen the PR (or push to its
 # branch) to run lint/validate before merging.
 on:
+  schedule:
+    # Monday 06:00 UTC — bump PRs land before the Saturday rebuild.
+    - cron: "0 6 * * 1"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Plan 3 Task 11: Sat 02:00 UTC full-matrix rebuild; Mon 06:00 UTC ISO point-release detector. Enabled now that all six lines are green. On schedule events the plan job's `github.event.inputs.os || 'all'` selects every enabled line.