### PR TITLE
feat(ci): Windows matrix infrastructure

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -24,6 +24,9 @@ on:
           - debian-13
           - rocky-9
           - almalinux-9
+          - windows-server-2025
+          - windows-server-2022
+          - windows-desktop-11
 
 permissions:
   contents: read
@@ -58,7 +61,7 @@ jobs:
         run: |
           set -euo pipefail
           matrix="$(jq -c --arg sel "$SELECTED" \
-            '[ .[] | select(.enabled and ($sel == "all" or .key == $sel)) ]' \
+            '[ .[] | select((($sel == "all") and .enabled) or ($sel == .key)) ]' \
             ci/matrix.json)"
           test "$(jq 'length' <<<"$matrix")" -gt 0
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
@@ -66,7 +69,7 @@ jobs:
   build:
     needs: plan
     runs-on: packer-vsphere
-    timeout-minutes: 150
+    timeout-minutes: ${{ matrix.timeout_minutes || 150 }}
     strategy:
       fail-fast: false
       # Scale set maxRunners is 3 — leave one slot free for ad-hoc jobs.
@@ -88,10 +91,18 @@ jobs:
           BUILD_OS: ${{ matrix.os }}
           BUILD_DIST: ${{ matrix.dist }}
           BUILD_VERSION: ${{ matrix.version }}
+          BUILD_EDITION: ${{ matrix.edition }}
+          BUILD_ONLY: ${{ matrix.only }}
         run: |
           set -euo pipefail
-          ./build.sh --ci --os "$BUILD_OS" --dist "$BUILD_DIST" \
-            --version "$BUILD_VERSION" "$GITHUB_WORKSPACE/ci/config"
+          args=( --ci --os "$BUILD_OS" --dist "$BUILD_DIST" --version "$BUILD_VERSION" )
+          if [ -n "${BUILD_EDITION:-}" ]; then
+            args+=( --edition "$BUILD_EDITION" )
+          fi
+          if [ -n "${BUILD_ONLY:-}" ]; then
+            args+=( --only "$BUILD_ONLY" )
+          fi
+          ./build.sh "${args[@]}" "$GITHUB_WORKSPACE/ci/config"
 
       # Swap the freshly converted '<base>-build' template into the stable
       # name Terraform clones (<base>), keeping exactly one rollback

--- a/.github/workflows/upload-isos.yml
+++ b/.github/workflows/upload-isos.yml
@@ -23,6 +23,9 @@ on: # checkov:skip=CKV_GHA_7: fixed-set choice input; not a free-text injection 
           - debian-13
           - rocky-9
           - almalinux-9
+          - windows-server-2025
+          - windows-server-2022
+          - windows-desktop-11
 
 permissions:
   contents: read

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,34 +46,50 @@ jobs:
       - name: Packer fmt
         run: |
           set -euo pipefail
-          # Fail closed: a malformed matrix or zero enabled entries must fail
-          # the check, not silently validate nothing (process substitution
+          # Fail closed: a malformed matrix or zero entries must fail the
+          # check, not silently validate nothing (process substitution
           # discards jq's exit status).
-          jq -e 'type=="array" and ([.[] | select(.enabled)] | length > 0)' ci/matrix.json >/dev/null
+          jq -e 'type=="array" and length > 0' ci/matrix.json >/dev/null
           packer fmt -check -recursive ci/config
           while IFS= read -r dir; do
             packer fmt -check -recursive "$dir"
-          done < <(jq -r '.[] | select(.enabled) | .build_dir' ci/matrix.json)
+          done < <(jq -r '.[] | .build_dir' ci/matrix.json)
 
-      - name: Packer validate (all enabled matrix lines)
+      - name: Packer validate (all matrix lines, including disabled)
         run: |
           set -euo pipefail
-          # Fail closed: a malformed matrix or zero enabled entries must fail
-          # the check, not silently validate nothing (process substitution
+          # Fail closed: a malformed matrix or zero entries must fail the
+          # check, not silently validate nothing (process substitution
           # discards jq's exit status).
-          jq -e 'type=="array" and ([.[] | select(.enabled)] | length > 0)' ci/matrix.json >/dev/null
+          jq -e 'type=="array" and length > 0' ci/matrix.json >/dev/null
           while IFS=$'\t' read -r dir cfg; do
             echo "::group::validate ${dir}"
             packer init "$dir"
-            packer validate \
-              -var-file=ci/config/vsphere.pkrvars.hcl \
-              -var-file=ci/config/build.pkrvars.hcl \
-              -var-file=ci/config/ansible.pkrvars.hcl \
-              -var-file=ci/config/proxy.pkrvars.hcl \
-              -var-file=ci/config/common.pkrvars.hcl \
-              -var-file=ci/config/network.pkrvars.hcl \
-              -var-file=ci/config/linux-storage.pkrvars.hcl \
-              -var-file="ci/config/${cfg}" \
-              "$dir"
+            case "$dir" in
+              builds/windows/*)
+                # Windows declares no network/storage variables — passing the
+                # Linux var-files would fail with undefined-variable errors.
+                packer validate \
+                  -var-file=ci/config/vsphere.pkrvars.hcl \
+                  -var-file=ci/config/build.pkrvars.hcl \
+                  -var-file=ci/config/ansible.pkrvars.hcl \
+                  -var-file=ci/config/proxy.pkrvars.hcl \
+                  -var-file=ci/config/common.pkrvars.hcl \
+                  -var-file="ci/config/${cfg}" \
+                  "$dir"
+                ;;
+              *)
+                packer validate \
+                  -var-file=ci/config/vsphere.pkrvars.hcl \
+                  -var-file=ci/config/build.pkrvars.hcl \
+                  -var-file=ci/config/ansible.pkrvars.hcl \
+                  -var-file=ci/config/proxy.pkrvars.hcl \
+                  -var-file=ci/config/common.pkrvars.hcl \
+                  -var-file=ci/config/network.pkrvars.hcl \
+                  -var-file=ci/config/linux-storage.pkrvars.hcl \
+                  -var-file="ci/config/${cfg}" \
+                  "$dir"
+                ;;
+            esac
             echo "::endgroup::"
-          done < <(jq -r '.[] | select(.enabled) | [.build_dir, .config] | @tsv' ci/matrix.json)
+          done < <(jq -r '.[] | [.build_dir, .config] | @tsv' ci/matrix.json)

--- a/build.sh
+++ b/build.sh
@@ -212,6 +212,7 @@ os=""
 dist=""
 version=""
 edition=""
+only_filter=""
 auto_continue=false
 ci_mode=false
 on_error_option="-on-error=ask"
@@ -238,6 +239,11 @@ while (("$#")); do
         ;;
     --edition)
         edition="$2"
+        shift 2
+        ;;
+    # --only: CI passthrough — restrict a Windows edition build to one packer source (e.g. dexp without core).
+    --only)
+        only_filter="$2"
         shift 2
         ;;
     --version)
@@ -887,7 +893,7 @@ select_build() {
             validate_windows_username "$config_path/build.pkrvars.hcl"
             printf "Starting the build of %s %s...\n\n" "$dist" "$version"
             command="packer build -force $on_error_option $debug_option"
-            command+=" --only=vsphere-iso.windows-server-standard-dexp,vsphere-iso.windows-server-standard-core"
+            command+=" --only=${only_filter:-vsphere-iso.windows-server-standard-dexp,vsphere-iso.windows-server-standard-core}"
 
             for var_file in "${var_files[@]}"; do
                 command+=" -var-file=\"$config_path/${!var_file}\""
@@ -908,7 +914,7 @@ select_build() {
             validate_windows_username "$config_path/build.pkrvars.hcl"
             printf "Starting the build of %s %s...\n\n" "$dist" "$version"
             command="packer build -force $on_error_option $debug_option"
-            command+=" --only vsphere-iso.windows-server-datacenter-dexp,vsphere-iso.windows-server-datacenter-core"
+            command+=" --only ${only_filter:-vsphere-iso.windows-server-datacenter-dexp,vsphere-iso.windows-server-datacenter-core}"
 
             for var_file in "${var_files[@]}"; do
                 command+=" -var-file=\"$config_path/${!var_file}\""

--- a/builds/windows/desktop/10/windows.pkr.hcl
+++ b/builds/windows/desktop/10/windows.pkr.hcl
@@ -47,18 +47,18 @@ locals {
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
     tools           = "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"
   }
-  manifest_date      = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path      = "${path.cwd}/manifests/"
-  manifest_output    = "${local.manifest_path}${local.manifest_date}.json"
-  ovf_export_path    = "${path.cwd}/artifacts/"
-  base_name_pro      = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_pro}-${local.build_version}"
-  base_name_ent      = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_ent}-${local.build_version}"
-  vm_name_pro        = "${local.base_name_pro}-build"
-  vm_name_ent        = "${local.base_name_ent}-build"
+  manifest_date            = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path            = "${path.cwd}/manifests/"
+  manifest_output          = "${local.manifest_path}${local.manifest_date}.json"
+  ovf_export_path          = "${path.cwd}/artifacts/"
+  base_name_pro            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_pro}-${local.build_version}"
+  base_name_ent            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_ent}-${local.build_version}"
+  vm_name_pro              = "${local.base_name_pro}-build"
+  vm_name_ent              = "${local.base_name_ent}-build"
   content_library_item_pro = local.base_name_pro
   content_library_item_ent = local.base_name_ent
-  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  bucket_name              = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description       = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/builds/windows/desktop/11/windows.pkr.hcl
+++ b/builds/windows/desktop/11/windows.pkr.hcl
@@ -47,18 +47,18 @@ locals {
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
     tools           = "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"
   }
-  manifest_date      = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path      = "${path.cwd}/manifests/"
-  manifest_output    = "${local.manifest_path}${local.manifest_date}.json"
-  ovf_export_path    = "${path.cwd}/artifacts/"
-  base_name_pro      = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_pro}-${local.build_version}"
-  base_name_ent      = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_ent}-${local.build_version}"
-  vm_name_pro        = "${local.base_name_pro}-build"
-  vm_name_ent        = "${local.base_name_ent}-build"
+  manifest_date            = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path            = "${path.cwd}/manifests/"
+  manifest_output          = "${local.manifest_path}${local.manifest_date}.json"
+  ovf_export_path          = "${path.cwd}/artifacts/"
+  base_name_pro            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_pro}-${local.build_version}"
+  base_name_ent            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_ent}-${local.build_version}"
+  vm_name_pro              = "${local.base_name_pro}-build"
+  vm_name_ent              = "${local.base_name_ent}-build"
   content_library_item_pro = local.base_name_pro
   content_library_item_ent = local.base_name_ent
-  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  bucket_name              = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description       = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/builds/windows/server/2019/windows-server.pkr.hcl
+++ b/builds/windows/server/2019/windows-server.pkr.hcl
@@ -47,24 +47,24 @@ locals {
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
     tools           = "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"
   }
-  manifest_date              = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path              = "${path.cwd}/manifests/"
-  manifest_output            = "${local.manifest_path}${local.manifest_date}.json"
-  ovf_export_path            = "${path.cwd}/artifacts/"
-  base_name_datacenter_core    = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_core}-${local.build_version}"
-  base_name_datacenter_desktop = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
-  base_name_standard_core      = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_core}-${local.build_version}"
-  base_name_standard_desktop   = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
-  vm_name_datacenter_core      = "${local.base_name_datacenter_core}-build"
-  vm_name_datacenter_desktop   = "${local.base_name_datacenter_desktop}-build"
-  vm_name_standard_core        = "${local.base_name_standard_core}-build"
-  vm_name_standard_desktop     = "${local.base_name_standard_desktop}-build"
+  manifest_date                           = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path                           = "${path.cwd}/manifests/"
+  manifest_output                         = "${local.manifest_path}${local.manifest_date}.json"
+  ovf_export_path                         = "${path.cwd}/artifacts/"
+  base_name_datacenter_core               = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_core}-${local.build_version}"
+  base_name_datacenter_desktop            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
+  base_name_standard_core                 = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_core}-${local.build_version}"
+  base_name_standard_desktop              = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
+  vm_name_datacenter_core                 = "${local.base_name_datacenter_core}-build"
+  vm_name_datacenter_desktop              = "${local.base_name_datacenter_desktop}-build"
+  vm_name_standard_core                   = "${local.base_name_standard_core}-build"
+  vm_name_standard_desktop                = "${local.base_name_standard_desktop}-build"
   content_library_item_datacenter_core    = local.base_name_datacenter_core
   content_library_item_datacenter_desktop = local.base_name_datacenter_desktop
   content_library_item_standard_core      = local.base_name_standard_core
   content_library_item_standard_desktop   = local.base_name_standard_desktop
-  bucket_name                = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description         = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  bucket_name                             = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description                      = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/builds/windows/server/2022/windows-server.pkr.hcl
+++ b/builds/windows/server/2022/windows-server.pkr.hcl
@@ -47,24 +47,24 @@ locals {
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
     tools           = "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"
   }
-  manifest_date              = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path              = "${path.cwd}/manifests/"
-  manifest_output            = "${local.manifest_path}${local.manifest_date}.json"
-  ovf_export_path            = "${path.cwd}/artifacts/"
-  base_name_datacenter_core    = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_core}-${local.build_version}"
-  base_name_datacenter_desktop = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
-  base_name_standard_core      = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_core}-${local.build_version}"
-  base_name_standard_desktop   = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
-  vm_name_datacenter_core      = "${local.base_name_datacenter_core}-build"
-  vm_name_datacenter_desktop   = "${local.base_name_datacenter_desktop}-build"
-  vm_name_standard_core        = "${local.base_name_standard_core}-build"
-  vm_name_standard_desktop     = "${local.base_name_standard_desktop}-build"
+  manifest_date                           = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path                           = "${path.cwd}/manifests/"
+  manifest_output                         = "${local.manifest_path}${local.manifest_date}.json"
+  ovf_export_path                         = "${path.cwd}/artifacts/"
+  base_name_datacenter_core               = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_core}-${local.build_version}"
+  base_name_datacenter_desktop            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
+  base_name_standard_core                 = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_core}-${local.build_version}"
+  base_name_standard_desktop              = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
+  vm_name_datacenter_core                 = "${local.base_name_datacenter_core}-build"
+  vm_name_datacenter_desktop              = "${local.base_name_datacenter_desktop}-build"
+  vm_name_standard_core                   = "${local.base_name_standard_core}-build"
+  vm_name_standard_desktop                = "${local.base_name_standard_desktop}-build"
   content_library_item_datacenter_core    = local.base_name_datacenter_core
   content_library_item_datacenter_desktop = local.base_name_datacenter_desktop
   content_library_item_standard_core      = local.base_name_standard_core
   content_library_item_standard_desktop   = local.base_name_standard_desktop
-  bucket_name                = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description         = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  bucket_name                             = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description                      = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/builds/windows/server/2025/windows-server.pkr.hcl
+++ b/builds/windows/server/2025/windows-server.pkr.hcl
@@ -47,24 +47,24 @@ locals {
     datastore       = "[${var.common_iso_datastore}] ${var.iso_datastore_path}/${var.iso_file}"
     tools           = "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"
   }
-  manifest_date              = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path              = "${path.cwd}/manifests/"
-  manifest_output            = "${local.manifest_path}${local.manifest_date}.json"
-  ovf_export_path            = "${path.cwd}/artifacts/"
-  base_name_datacenter_core    = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_core}-${local.build_version}"
-  base_name_datacenter_desktop = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
-  base_name_standard_core      = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_core}-${local.build_version}"
-  base_name_standard_desktop   = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
-  vm_name_datacenter_core      = "${local.base_name_datacenter_core}-build"
-  vm_name_datacenter_desktop   = "${local.base_name_datacenter_desktop}-build"
-  vm_name_standard_core        = "${local.base_name_standard_core}-build"
-  vm_name_standard_desktop     = "${local.base_name_standard_desktop}-build"
+  manifest_date                           = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path                           = "${path.cwd}/manifests/"
+  manifest_output                         = "${local.manifest_path}${local.manifest_date}.json"
+  ovf_export_path                         = "${path.cwd}/artifacts/"
+  base_name_datacenter_core               = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_core}-${local.build_version}"
+  base_name_datacenter_desktop            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_datacenter}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
+  base_name_standard_core                 = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_core}-${local.build_version}"
+  base_name_standard_desktop              = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${var.vm_guest_os_edition_standard}-${var.vm_guest_os_experience_desktop}-${local.build_version}"
+  vm_name_datacenter_core                 = "${local.base_name_datacenter_core}-build"
+  vm_name_datacenter_desktop              = "${local.base_name_datacenter_desktop}-build"
+  vm_name_standard_core                   = "${local.base_name_standard_core}-build"
+  vm_name_standard_desktop                = "${local.base_name_standard_desktop}-build"
   content_library_item_datacenter_core    = local.base_name_datacenter_core
   content_library_item_datacenter_desktop = local.base_name_datacenter_desktop
   content_library_item_standard_core      = local.base_name_standard_core
   content_library_item_standard_desktop   = local.base_name_standard_desktop
-  bucket_name                = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description         = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  bucket_name                             = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description                      = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/ci/config/windows-desktop-11.pkrvars.hcl
+++ b/ci/config/windows-desktop-11.pkrvars.hcl
@@ -1,0 +1,23 @@
+/*
+    CI config — Windows 11 Desktop build (Enterprise source only).
+    Keys are PUBLIC Microsoft GVLK client keys — activation happens against
+    a KMS host at clone time, not at build.
+    Both edition keys must hold values: all sources' locals interpolate
+    eagerly even when -only excludes them.
+    iso_file is set to the user's licensed media filename (Task 2).
+*/
+
+// Installation Operating System Metadata
+vm_inst_os_key_pro = "W269N-WFGWX-YVC9B-4J6C9-T83GX"
+vm_inst_os_key_ent = "NPPR9-FWDCX-D2C8J-H872K-2YT43"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "windows9_64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware = "efi-secure"
+
+// Removable Media Settings
+iso_datastore_path       = "iso/windows/windows-desktop/11/amd64"
+iso_content_library_item = "windows-desktop-11"
+iso_file                 = "windows-desktop-11.iso"

--- a/ci/config/windows-server-2022.pkrvars.hcl
+++ b/ci/config/windows-server-2022.pkrvars.hcl
@@ -1,0 +1,23 @@
+/*
+    CI config — Windows Server 2022 build (datacenter-dexp source only via
+    the matrix 'only' filter). Keys are PUBLIC Microsoft GVLK client keys —
+    activation happens against a KMS host at clone time, not at build.
+    Both edition keys must hold values: all sources' locals interpolate
+    eagerly even when -only excludes them.
+    iso_file is set to the user's licensed media filename (Task 2).
+*/
+
+// Installation Operating System Metadata
+vm_inst_os_key_standard   = "VDYBN-27WPP-V4HQT-9VMD4-VMK7H"
+vm_inst_os_key_datacenter = "WX4NM-KYWYW-QJJR4-XV3QB-6VM33"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "windows2019srvNext_64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware = "efi-secure"
+
+// Removable Media Settings
+iso_datastore_path       = "iso/windows/windows-server/2022/amd64"
+iso_content_library_item = "windows-server-2022"
+iso_file                 = "windows-server-2022.iso"

--- a/ci/config/windows-server-2025.pkrvars.hcl
+++ b/ci/config/windows-server-2025.pkrvars.hcl
@@ -1,0 +1,23 @@
+/*
+    CI config — Windows Server 2025 build (datacenter-dexp source only via
+    the matrix 'only' filter). Keys are PUBLIC Microsoft GVLK client keys —
+    activation happens against a KMS host at clone time, not at build.
+    Both edition keys must hold values: all sources' locals interpolate
+    eagerly even when -only excludes them.
+    iso_file is set to the user's licensed media filename (Task 2).
+*/
+
+// Installation Operating System Metadata
+vm_inst_os_key_standard   = "TVRH6-WHNXV-R9WG3-9XRFY-MY832"
+vm_inst_os_key_datacenter = "D764K-2NDRG-47T6Q-P8T8W-YP6DF"
+
+// Virtual Machine Guest Operating System Setting
+vm_guest_os_type = "windows2022srvNext_64Guest"
+
+// Virtual Machine Hardware Settings
+vm_firmware = "efi-secure"
+
+// Removable Media Settings
+iso_datastore_path       = "iso/windows/windows-server/2025/amd64"
+iso_content_library_item = "windows-server-2025"
+iso_file                 = "windows-server-2025.iso"

--- a/ci/matrix.json
+++ b/ci/matrix.json
@@ -112,5 +112,46 @@
       "url_template": "https://repo.almalinux.org/almalinux/{ver}/isos/x86_64/AlmaLinux-{ver}-x86_64-dvd.iso",
       "sums_template": "https://repo.almalinux.org/almalinux/{ver}/isos/x86_64/CHECKSUM"
     }
+  },
+  {
+    "key": "windows-server-2025",
+    "enabled": false,
+    "os": "Windows",
+    "dist": "Windows Server",
+    "version": "2025",
+    "edition": "Datacenter",
+    "only": "vsphere-iso.windows-server-datacenter-dexp",
+    "build_dir": "builds/windows/server/2025",
+    "config": "windows-server-2025.pkrvars.hcl",
+    "base_name": "windows-server-2025-datacenter-dexp-main",
+    "iso_datastore_path": "iso/windows/windows-server/2025/amd64",
+    "timeout_minutes": 240
+  },
+  {
+    "key": "windows-server-2022",
+    "enabled": false,
+    "os": "Windows",
+    "dist": "Windows Server",
+    "version": "2022",
+    "edition": "Datacenter",
+    "only": "vsphere-iso.windows-server-datacenter-dexp",
+    "build_dir": "builds/windows/server/2022",
+    "config": "windows-server-2022.pkrvars.hcl",
+    "base_name": "windows-server-2022-datacenter-dexp-main",
+    "iso_datastore_path": "iso/windows/windows-server/2022/amd64",
+    "timeout_minutes": 240
+  },
+  {
+    "key": "windows-desktop-11",
+    "enabled": false,
+    "os": "Windows",
+    "dist": "Windows Desktop",
+    "version": "11",
+    "edition": "Enterprise",
+    "build_dir": "builds/windows/desktop/11",
+    "config": "windows-desktop-11.pkrvars.hcl",
+    "base_name": "windows-desktop-11-ent-main",
+    "iso_datastore_path": "iso/windows/windows-desktop/11/amd64",
+    "timeout_minutes": 240
   }
 ]

--- a/ci/scripts/upload-isos.sh
+++ b/ci/scripts/upload-isos.sh
@@ -28,6 +28,10 @@ while IFS= read -r entry; do
 		continue
 	fi
 	matched=$((matched + 1))
+	if [ "$(jq -r 'has("iso_url")' <<<"$entry")" != "true" ]; then
+		echo "MANUAL-ISO ${key}: licensed media staged by hand — skipping"
+		continue
+	fi
 	iso_url="$(jq -r '.iso_url' <<<"$entry")"
 	sums_url="$(jq -r '.sums_url' <<<"$entry")"
 	ds_path="$(jq -r '.iso_datastore_path' <<<"$entry")"

--- a/ci/scripts/upload-isos.sh
+++ b/ci/scripts/upload-isos.sh
@@ -9,16 +9,17 @@
 # Requires: govc env (GOVC_URL/USERNAME/PASSWORD/INSECURE), jq, curl.
 # ISOs are staged in RUNNER_TEMP (the runner work volume) one at a time —
 # peak disk use is a single ISO (largest line ~11 GB EL dvd vs 25 Gi volume).
+# Disabled matrix entries are processed too: staging an ISO ahead of enabling a line is harmless and idempotent.
 set -euo pipefail
 
 selected="${1:?usage: upload-isos.sh <key|all>}"
 tmpdir="${RUNNER_TEMP:-/tmp}"
 datastore="$(grep -E '^common_iso_datastore ' ci/config/common.pkrvars.hcl | awk -F '"' '{print $2}')"
 
-# Fail closed: a malformed matrix or zero enabled entries must fail the run,
+# Fail closed: a malformed matrix or an empty matrix must fail the run,
 # not silently upload nothing (process substitution discards jq's exit
 # status). Also catches an empty datastore extraction.
-jq -e 'type=="array" and ([.[] | select(.enabled)] | length > 0)' ci/matrix.json >/dev/null
+jq -e 'type=="array" and length > 0' ci/matrix.json >/dev/null
 test -n "$datastore"
 
 matched=0
@@ -70,9 +71,9 @@ while IFS= read -r entry; do
 	govc datastore.upload -ds "$datastore" "${tmpdir}/${file}" "${ds_path}/.${file}.partial"
 	govc datastore.mv -ds "$datastore" "${ds_path}/.${file}.partial" "${ds_path}/${file}"
 	rm -f "${tmpdir}/${file}"
-done < <(jq -c '.[] | select(.enabled)' ci/matrix.json)
+done < <(jq -c '.[]' ci/matrix.json)
 
 if [ "$matched" -eq 0 ]; then
-	echo "ERROR: no enabled matrix entry matched key '${selected}'" >&2
+	echo "ERROR: no matrix entry matched key '${selected}'" >&2
 	exit 1
 fi


### PR DESCRIPTION
Plan 4 Task 1: matrix gains edition/only/timeout + manual-ISO entries (enabled:false until VLAN migration); build.sh --only passthrough so Datacenter builds dexp without core; named dispatch keys may build disabled entries; validate covers disabled entries with per-family var-files.

## Changes

- **build.sh**: `--only` flag passthrough (init + parser + two Windows Server edition cases); defaults preserve existing behaviour when flag is absent
- **ci/matrix.json**: three new entries — `windows-server-2025`, `windows-server-2022`, `windows-desktop-11` (all `enabled: false`; no `iso_url`/`sums_url`/`discover` — manual licensed media)
- **build-templates.yml**: plan-job filter uses disabled-key-override logic; build step gains env-indirected `BUILD_EDITION`/`BUILD_ONLY` optional flags; `timeout-minutes` uses `matrix.timeout_minutes || 150`; three new dispatch options
- **upload-isos.yml**: three new dispatch options
- **ci/scripts/upload-isos.sh**: MANUAL-ISO skip for entries without `iso_url` (counter still increments so dispatching a manual key isn't an error)
- **validate.yml**: both jq guards relaxed to `length > 0` (all entries); fmt + validate loops cover all entries; validate branches on `builds/windows/*` to omit Linux-only var-files
- **ci/config/windows-server-2025.pkrvars.hcl**: GVLKs + `vm_guest_os_type=windows2022srvNext_64Guest` + iso placeholder
- **ci/config/windows-server-2022.pkrvars.hcl**: GVLKs + `vm_guest_os_type=windows2019srvNext_64Guest` (from 2022 example) + iso placeholder
- **ci/config/windows-desktop-11.pkrvars.hcl**: GVLKs + `vm_guest_os_type=windows9_64Guest` + iso placeholder
- **builds/windows/{desktop/10,desktop/11,server/2019,server/2022,server/2025}**: `packer fmt` pure-whitespace fixes (pre-existing misalignments)

## Verification

- `bash -n build.sh` — syntax OK
- `grep -n only_filter build.sh` — 4 hits (init, parser, two edition cases)
- jq filter for `windows-server-2025` key → 1; jq filter for `all` → 6 (Windows excluded as disabled)
- `packer validate` for all three Windows dirs — all pass with dummy env
- `packer fmt -check -recursive ci/config builds/windows` — clean
- `shellcheck ci/scripts/upload-isos.sh` — clean
- YAML parse — all workflow files OK