### PR TITLE
chore(deps): batch .mise.toml tool pins (supersedes #21 #19 #18 #12 #6)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -18,16 +18,16 @@
 
 [tools]
 packer       = "1.15.4"   # >= 1.15.0 required by builds/
-ansible-core = "2.20.6"   # >= 2.16 required by builds/
-gomplate     = "4.3.3"    # >= 4.3.0 required for build-ci.tmpl
-terraform    = "1.10.0"
+ansible-core = "2.21.0"   # >= 2.16 required by builds/
+gomplate     = "5.1.0"    # >= 4.3.0 required for build-ci.tmpl
+terraform    = "1.15.6"
 # docs require jq >= 1.8.3 but 1.8.1 is the newest in the mise registry;
 # no build path depends on the 1.8.2+ fixes.
 jq           = "1.8.1"
 # CI/runner tooling (used by the in-cluster runner image and smoke tests)
-"aqua:vmware/govmomi/govc" = "0.49.0"  # vCenter CLI (mise id is the aqua backend, NOT bare "govc")
+"aqua:vmware/govmomi/govc" = "0.54.1"  # vCenter CLI (mise id is the aqua backend, NOT bare "govc")
 goss = "0.4.9"    # post-build smoke assertions
-gh   = "2.62.0"   # GitHub CLI: open ISO-bump PRs from workflows
+gh   = "2.94.0"   # GitHub CLI: open ISO-bump PRs from workflows
 
 # git >= 2.43.0 and xorriso >= 1.5.6 (Linux) come from the system package
 # manager / runner image, not mise.


### PR DESCRIPTION
One PR for the five stale Renovate .mise.toml bumps (they conflict with each other serially). All verified resolvable via mise install. gomplate v5 major is safe: only used by build.sh --deps (never in CI) and a commented gitlab template.