### PR TITLE
fix(lint): suppress zizmor artipacked for docs.yml and release.yml

### DIFF
--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -3,10 +3,15 @@
 # (LINTER_RULES_PATH default = .github/linters, file name = zizmor.yaml).
 rules:
   artipacked:
-    # check-iso-updates.yml intentionally keeps persist-credentials at its
-    # default (true) so the subsequent "git push --force origin $branch" step
-    # can write to the repository.  All other workflows set
-    # persist-credentials: false explicitly.
+    # These workflows intentionally keep persist-credentials at its default
+    # (true) because later steps push with plain git over the persisted
+    # extraheader credential:
+    #   - check-iso-updates.yml: "git push --force origin $branch"
+    #   - docs.yml: "mkdocs gh-deploy --force" pushes the gh-pages branch
+    #   - release.yml: pushes release/<version> and rebases/pushes main
+    # All other workflows set persist-credentials: false explicitly.
     # Ignore key is the workflow basename only (not the full path).
     ignore:
       - check-iso-updates.yml
+      - docs.yml
+      - release.yml


### PR DESCRIPTION
## Why
Lint run 215 on main (push of the checkout v6.0.3 bump, #8) failed: zizmor's \`artipacked\` audit flagged the checkout steps in \`docs.yml\` and \`release.yml\` for not setting \`persist-credentials: false\`. Later runs went green only because super-linter validates changed files — the finding is latent and will re-fire whenever these files are touched.

## Why not persist-credentials: false
Both workflows rely on the persisted extraheader credential:
- \`docs.yml\` — \`mkdocs gh-deploy --force\` pushes the \`gh-pages\` branch
- \`release.yml\` — plain \`git push\` of \`release/<version>\` and the main rebase (its \`GITHUB_TOKEN\` env vars don't configure git auth)

## Fix
Add both basenames to the existing \`artipacked\` ignore list in \`.github/linters/zizmor.yaml\`, alongside \`check-iso-updates.yml\` which is suppressed for the same reason.