### PR TITLE
fix(ci): Windows licensed install — write GVLK (vm_inst_os_eval=false) + 60m ip_wait_timeout

### DIFF
--- a/ci/config/windows-desktop-11.pkrvars.hcl
+++ b/ci/config/windows-desktop-11.pkrvars.hcl
@@ -17,6 +17,14 @@ vm_guest_os_type = "windows9_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware = "efi-secure"
 
+// Boot/Provisioning Timing Override
+// Windows reports its IP only after install + the first-logon VMware Tools
+// setup (much later than Linux cloud-init), so the shared 20m
+// common_ip_wait_timeout (ci/config/common.pkrvars.hcl) times out. Per-OS
+// var-files load AFTER common.pkrvars.hcl, so this overrides it for Windows
+// builds only.
+common_ip_wait_timeout = "60m"
+
 // Removable Media Settings
 iso_datastore_path       = "iso/windows/windows-desktop/11/amd64"
 iso_content_library_item = "windows-desktop-11"

--- a/ci/config/windows-desktop-11.pkrvars.hcl
+++ b/ci/config/windows-desktop-11.pkrvars.hcl
@@ -11,6 +11,11 @@
 vm_inst_os_key_pro = "W269N-WFGWX-YVC9B-4J6C9-T83GX"
 vm_inst_os_key_ent = "NPPR9-FWDCX-D2C8J-H872K-2YT43"
 
+// Licensed install (NOT evaluation). The autounattend only writes the
+// <ProductKey> (the GVLK above) when this is false; at the default (true)
+// the key is omitted and Setup stalls waiting for product-key input.
+vm_inst_os_eval = false
+
 // Virtual Machine Guest Operating System Setting
 vm_guest_os_type = "windows9_64Guest"
 

--- a/ci/config/windows-server-2022.pkrvars.hcl
+++ b/ci/config/windows-server-2022.pkrvars.hcl
@@ -17,6 +17,14 @@ vm_guest_os_type = "windows2019srvNext_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware = "efi-secure"
 
+// Boot/Provisioning Timing Override
+// Windows reports its IP only after install + the first-logon VMware Tools
+// setup (much later than Linux cloud-init), so the shared 20m
+// common_ip_wait_timeout (ci/config/common.pkrvars.hcl) times out. Per-OS
+// var-files load AFTER common.pkrvars.hcl, so this overrides it for Windows
+// builds only.
+common_ip_wait_timeout = "60m"
+
 // Removable Media Settings
 iso_datastore_path       = "iso/windows/windows-server/2022/amd64"
 iso_content_library_item = "windows-server-2022"

--- a/ci/config/windows-server-2022.pkrvars.hcl
+++ b/ci/config/windows-server-2022.pkrvars.hcl
@@ -11,6 +11,11 @@
 vm_inst_os_key_standard   = "VDYBN-27WPP-V4HQT-9VMD4-VMK7H"
 vm_inst_os_key_datacenter = "WX4NM-KYWYW-QJJR4-XV3QB-6VM33"
 
+// Licensed install (NOT evaluation). The autounattend only writes the
+// <ProductKey> (the GVLK above) when this is false; at the default (true)
+// the key is omitted and Setup stalls waiting for product-key input.
+vm_inst_os_eval = false
+
 // Virtual Machine Guest Operating System Setting
 vm_guest_os_type = "windows2019srvNext_64Guest"
 

--- a/ci/config/windows-server-2025.pkrvars.hcl
+++ b/ci/config/windows-server-2025.pkrvars.hcl
@@ -11,6 +11,12 @@
 vm_inst_os_key_standard   = "TVRH6-WHNXV-R9WG3-9XRFY-MY832"
 vm_inst_os_key_datacenter = "D764K-2NDRG-47T6Q-P8T8W-YP6DF"
 
+// Licensed install (NOT evaluation). The autounattend only writes the
+// <ProductKey> (the GVLK above) when this is false; at the default (true)
+// the key is omitted and Server 2025's new Setup stalls at the
+// "Choose a licensing method" screen waiting for product-key input.
+vm_inst_os_eval = false
+
 // Virtual Machine Guest Operating System Setting
 vm_guest_os_type = "windows2022srvNext_64Guest"
 

--- a/ci/config/windows-server-2025.pkrvars.hcl
+++ b/ci/config/windows-server-2025.pkrvars.hcl
@@ -17,6 +17,14 @@ vm_guest_os_type = "windows2022srvNext_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware = "efi-secure"
 
+// Boot/Provisioning Timing Override
+// Windows reports its IP only after install + the first-logon VMware Tools
+// setup (much later than Linux cloud-init), so the shared 20m
+// common_ip_wait_timeout (ci/config/common.pkrvars.hcl) times out. Per-OS
+// var-files load AFTER common.pkrvars.hcl, so this overrides it for Windows
+// builds only.
+common_ip_wait_timeout = "60m"
+
 // Removable Media Settings
 iso_datastore_path       = "iso/windows/windows-server/2025/amd64"
 iso_content_library_item = "windows-server-2025"


### PR DESCRIPTION
**Root cause (run 27464429995):** the build hung on `timeout waiting for IP`. Console screenshot showed Windows Server Setup **stuck on the new 'Choose a licensing method' screen** waiting for product-key input. `vm_inst_os_eval` defaults to `true`, and the autounattend only emits `<ProductKey>` when it's false (`%{if vm_inst_os_eval != true ~}`) — so the **GVLK was silently dropped**, Setup waited forever, no IP, 20m timeout.

(The 2025 templates from 2025-10-16 in the Content Library were built from older Sep-2025 media; the May-2026 media uses Microsoft's redesigned Setup with the Azure pay-as-you-go licensing screen, which exposed this.)

**Fixes (3 Windows configs):**
1. `vm_inst_os_eval = false` — writes the GVLK (datacenter key for the dexp source), auto-answering the licensing screen. *This is the unblock.*
2. `common_ip_wait_timeout = 60m` — Windows reports its IP only after install→Tools, which exceeds the shared 20m Linux default once the install actually proceeds. Per-OS override, zero Linux impact.

Validated on the branch ref via build-templates dispatch before merge.