### PR TITLE
fix(ansible): ansible_shell_type=cmd for Windows WinRM

### DIFF
--- a/ansible/windows-playbook.yml
+++ b/ansible/windows-playbook.yml
@@ -3,6 +3,14 @@
   debugger: never
   gather_facts: true
   hosts: all
+  vars:
+    # Force the WinRM connection to use the 'cmd' shell, not 'powershell'.
+    # With ansible-core 2.21 + pywinrm 0.5 the default powershell shell type
+    # sends a malformed -EncodedCommand over WinRM ("value specified with
+    # -EncodedCommand is not properly encoded"), failing at Gathering Facts.
+    # ansible itself warns: "the winrm connection plugin should have the shell
+    # type of cmd and not powershell." cmd wraps commands correctly.
+    ansible_shell_type: cmd
   roles:
     - base
     - configure


### PR DESCRIPTION
Fourth and (hopefully) final layer of the Windows-build bring-up. With the runner image pinned (pywinrm now present), the build connects over WinRM but fails at `Gathering Facts`:

```
winrm send_input failed ... Cannot process the command because the value specified
with -EncodedCommand is not properly encoded.
```

ansible warns "the winrm connection plugin should have the shell type of cmd and not powershell." ansible-core 2.21 + pywinrm 0.5 default to a powershell shell type that mangles `-EncodedCommand`. Setting `ansible_shell_type=cmd` (once, in the shared windows playbook) fixes it for all Windows lines.