### PR TITLE
fix(ansible): harden Windows win_updates across reboots

### DIFF
--- a/ansible/roles/base/tasks/windows.yml
+++ b/ansible/roles/base/tasks/windows.yml
@@ -38,6 +38,13 @@
 #         state: latest
 #         ignore_checksums: true
 
+# Clear any reboot left pending by Setup/VMware Tools/specialize so the first
+# win_updates operation doesn't hit an unexpected reboot mid-scan (a cause of
+# the WS-Man "InvalidSelectors" fault when polling across a reboot).
+- name: Reboot to clear pending operations before patching.
+  ansible.windows.win_reboot:
+    reboot_timeout: 1800
+
 - name: Updating the operating system.
   ansible.windows.win_updates:
     category_names:
@@ -47,6 +54,9 @@
       - 5034439
       - 5034441
     reboot: true
+    # Server 2025 "Configuring updates" reboots can exceed the 1200s default;
+    # give the post-update reboot up to an hour to settle before polling.
+    reboot_timeout: 3600
   register: win_updates
   until: not win_updates.failed
   retries: 5

--- a/ansible/windows-playbook.yml
+++ b/ansible/windows-playbook.yml
@@ -11,6 +11,13 @@
     # ansible itself warns: "the winrm connection plugin should have the shell
     # type of cmd and not powershell." cmd wraps commands correctly.
     ansible_shell_type: cmd
+    # win_updates runs long-running update operations and reboots the host.
+    # The default 20s WinRM operation timeout is hit ("WSMan OperationTimeout
+    # during send input"), which destabilises the connection across the
+    # update reboot (Connection refused / InvalidSelectors). Raise both
+    # timeouts; read_timeout must exceed operation_timeout.
+    ansible_winrm_operation_timeout_sec: 120
+    ansible_winrm_read_timeout_sec: 150
   roles:
     - base
     - configure


### PR DESCRIPTION
windows-server-2025 now builds end-to-end into `win_updates` but fails after ~40m: the WinRM session drops across the update reboot (`Connection refused [Errno 111]`) and the async task's WS-Man shell goes stale (`InvalidSelectors`), exhausting the 5 retries. Matches [ansible.windows#143](https://github.com/ansible-collections/ansible.windows/issues/143) + the `WSMan OperationTimeout during send input` warning.

Three standard mitigations (shared playbook + base role, so all Windows lines benefit):
- WinRM timeouts op 120s / read 150s (20s default op timeout was being hit)
- pre-reboot before patching (clear pending reboot → avoid mid-scan reboot races)
- `reboot_timeout: 3600` on win_updates (Server 2025 update reboots are slow)