### PR TITLE
chore(ci): enable the 3 Windows matrix lines

### DIFF
--- a/ci/matrix.json
+++ b/ci/matrix.json
@@ -115,7 +115,7 @@
   },
   {
     "key": "windows-server-2025",
-    "enabled": false,
+    "enabled": true,
     "os": "Windows",
     "dist": "Windows Server",
     "version": "2025",
@@ -129,7 +129,7 @@
   },
   {
     "key": "windows-server-2022",
-    "enabled": false,
+    "enabled": true,
     "os": "Windows",
     "dist": "Windows Server",
     "version": "2022",
@@ -143,7 +143,7 @@
   },
   {
     "key": "windows-desktop-11",
-    "enabled": false,
+    "enabled": true,
     "os": "Windows",
     "dist": "Windows Desktop",
     "version": "11",


### PR DESCRIPTION
VLAN migration freed DHCP headroom, so flip the Windows entries (server 2025/2022 datacenter-dexp, desktop 11 ent) `enabled: false → true`. They now build in the weekly cron (Sat 02:00 UTC) and `all` dispatch alongside the 6 Linux lines — 9 total, `max-parallel: 2`. All three were proven green on-demand on 2026-06-13.