### PR TITLE
chore(ci): land ISO bumps on main without an approval gate

### DIFF
--- a/.github/workflows/check-iso-updates.yml
+++ b/.github/workflows/check-iso-updates.yml
@@ -1,23 +1,24 @@
 ---
 name: check-iso-updates
 
-# Weekly point-release detector for the free Linux distros. Opens a PR
-# bumping iso_url/sums_url (ci/matrix.json) + iso_file (ci/config). Human
-# merge is the gate; after merging, dispatch upload-isos for the bumped
-# line(s) so the next weekly build finds the new ISO on the datastore.
+# Weekly point-release detector for the free Linux distros. Commits a bump
+# of iso_url/sums_url (ci/matrix.json) + iso_file (ci/config) straight to
+# main — no PR, no approval gate — then dispatches upload-isos for each
+# bumped line so the next weekly build finds the new ISO on the datastore.
 #
-# Known limitation: PRs opened with the default GITHUB_TOKEN do not
-# trigger PR-check workflows — close and reopen the PR (or push to its
-# branch) to run lint/validate before merging.
+# validate.yml runs packer validate on push to main, so the bump is still
+# checked (post-merge). GITHUB_TOKEN can trigger the upload-isos
+# workflow_dispatch (the documented carve-out from the recursion rule that
+# blocks push/pull_request chains), so no PAT is required.
 on:
   schedule:
-    # Monday 06:00 UTC — bump PRs land before the Saturday rebuild.
+    # Monday 06:00 UTC — bumps land before the Saturday rebuild.
     - cron: "0 6 * * 1"
   workflow_dispatch: {}
 
 permissions:
   contents: write
-  pull-requests: write
+  actions: write
 
 concurrency:
   group: check-iso-updates
@@ -32,9 +33,11 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Detect point releases
-        run: python3 ci/scripts/check_iso_updates.py
+        # Tee the BUMP/OK lines to a file so the next step can map each
+        # bumped matrix key to an upload-isos dispatch.
+        run: python3 ci/scripts/check_iso_updates.py | tee "$RUNNER_TEMP/iso-bumps.log"
 
-      - name: Open bump PR if anything changed
+      - name: Commit bumps to main and stage ISOs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -43,23 +46,21 @@ jobs:
             echo "No ISO bumps."
             exit 0
           fi
-          # Stable branch + force push: repeated runs with an unmerged bump
-          # update ONE branch/PR instead of accumulating duplicates. Plain
-          # --force is safe here: the branch is bot-owned and always rebuilt
-          # from the freshly checked-out default branch (--force-with-lease
-          # cannot work under checkout@v4's single-branch fetch — no
-          # tracking ref to lease against).
-          branch="iso-bumps/auto"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
           git add ci/matrix.json ci/config/*.pkrvars.hcl
           git commit -m "chore(iso): bump ISO point releases"
-          git push --force origin "$branch"
-          if [ -n "$(gh pr list --repo "${{ github.repository }}" --head "$branch" --state open --json number --jq '.[].number')" ]; then
-            echo "Open bump PR already exists for $branch — branch updated."
-            exit 0
-          fi
-          gh pr create --repo "${{ github.repository }}" \
-            --title "chore(iso): bump ISO point releases" \
-            --body "Automated point-release bump from check-iso-updates. After merging, dispatch upload-isos for the affected line(s). Close/reopen this PR to trigger checks."
+          # Push straight to the default branch — ISO point-release bumps are
+          # low-risk and run no approval gate. validate.yml re-runs packer
+          # validate on the resulting push to main. Runs are serialised by the
+          # concurrency group above, so a non-fast-forward race is unlikely;
+          # if it happens the next scheduled run (or a manual dispatch) recovers.
+          git push origin HEAD:main
+          # Stage the freshly bumped ISOs on the datastore so the next weekly
+          # build finds them. upload-isos takes one matrix key per dispatch and
+          # its keys mirror the matrix keys printed as "BUMP <key>: ...".
+          keys=$(awk '/^BUMP /{k=$2; sub(/:$/, "", k); print k}' "$RUNNER_TEMP/iso-bumps.log")
+          for key in $keys; do
+            echo "Dispatching upload-isos for $key"
+            gh workflow run upload-isos.yml --repo "${{ github.repository }}" -f os="$key"
+          done

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,17 @@ on:
       - project.json
       - .github/workflows/validate.yml
       - ci/matrix.json
+  # check-iso-updates commits ISO bumps straight to main (no PR), so also
+  # validate on push to main to keep packer validate covering those bumps.
+  push:
+    branches: [main]
+    paths:
+      - builds/**
+      - ci/config/**
+      - build.sh
+      - project.json
+      - .github/workflows/validate.yml
+      - ci/matrix.json
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Removes the human merge gate from `check-iso-updates`. Instead of opening a bot PR (which never triggered checks under `GITHUB_TOKEN`) and waiting for a human merge, the workflow now:

- Commits the point-release bump straight to `main` (no PR, no approval gate).
- Auto-dispatches `upload-isos` for each bumped line, mapping every `BUMP <key>` line from the detector to `gh workflow run upload-isos -f os=<key>`. `GITHUB_TOKEN` can trigger `workflow_dispatch` (the documented carve-out from the recursion rule), so no PAT is needed.

To keep validation coverage, `validate.yml` now also runs on `push` to `main` (same path filter), so each bump is still `packer validate`'d post-merge.

### Changes
- `.github/workflows/check-iso-updates.yml`: commit-to-main + dispatch; `permissions` now `contents: write` + `actions: write` (dropped `pull-requests: write`).
- `.github/workflows/validate.yml`: add `push: [main]` trigger.

### Notes
- ISO bumps are low-risk point-release URL/checksum changes; validation moves from pre-merge (PR) to post-merge (push to main).
- Runs are serialised by the existing concurrency group, so a non-fast-forward race on the direct push is unlikely; the next scheduled run or a manual dispatch recovers.