### PR TITLE
docs: publish Zensical site to GitHub Pages + refocus off the fork

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -9,6 +9,14 @@ on:
   schedule:
     # Weekly rebuild, Saturday 02:00 UTC — all enabled lines (the plan job
     # defaults to 'all' when there is no dispatch input).
+    #
+    # Two GitHub scheduler caveats (neither is an approval gate):
+    #   - Cron is best-effort and is frequently delayed under load — observed
+    #     starts run hours after 02:00. Don't rely on the exact minute.
+    #   - GitHub auto-disables scheduled workflows after ~60 days with no
+    #     repository activity; re-enable from the Actions tab if it happens.
+    #     The Monday check-iso-updates commit to main normally keeps the repo
+    #     active enough to avoid this.
     - cron: "0 2 * * 6"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,69 @@
+---
+name: docs
+
+# Build the Zensical docs site and publish it to GitHub Pages
+# (https://codelooks-com.github.io/packer-vsphere/). Build runs on PRs too so a
+# broken site fails the check; deploy only happens on main / manual dispatch.
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - .github/workflows/docs.yml
+  pull_request:
+    paths:
+      - docs/**
+      - .github/workflows/docs.yml
+  workflow_dispatch: {}
+
+# Least privilege: build only reads, deploy gets the Pages/OIDC scopes.
+permissions: {}
+
+# Serialize Pages deploys; never cancel an in-flight publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Build site
+        run: |
+          set -euo pipefail
+          cd docs
+          pip install -r requirements.txt
+          zensical build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs/site
+
+  deploy:
+    # Publish only from main (or manual dispatch); PRs just validate the build.
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 # Packer vSphere Golden Images
 
-A fork of [`vmware/packer-examples-for-vsphere`][upstream], customised to build
-multi-OS golden-image templates on the Talos cluster's **ephemeral ARC runners**
-(no pinned build VM). Templates are consumed downstream by
-`codelooks-com/terraform-vsphere`.
+The `codelooks-com/packer-vsphere` pipeline builds multi-OS golden-image
+templates on the Talos cluster's **ephemeral ARC runners** (no pinned build VM).
+Templates are consumed downstream by
+[`codelooks-com/terraform-vsphere`](https://github.com/codelooks-com/terraform-vsphere).
 
 ## What it builds
 
@@ -34,17 +34,20 @@ folder · SSO domain `core.codelooks.com`.
 
 ## Documentation
 
-Internal docs live in [`docs/`](docs/) and are built with
-[Zensical](https://zensical.org/) — **not published**, build/preview locally:
+Full docs are published at
+**<https://codelooks-com.github.io/packer-vsphere/>** — built from [`docs/`](docs/)
+with [Zensical](https://zensical.org/) and deployed by
+[`.github/workflows/docs.yml`](.github/workflows/docs.yml) on every push to `main`.
+
+Start with [Architecture & Pipeline](https://codelooks-com.github.io/packer-vsphere/operations/architecture/)
+and [Windows Templates](https://codelooks-com.github.io/packer-vsphere/operations/windows/).
+To preview locally:
 
 ```bash
 cd docs
 pip install -r requirements.txt
 zensical serve   # http://localhost:8000
 ```
-
-Start with the [Architecture & Pipeline](docs/docs/operations/architecture.md)
-and [Windows Templates](docs/docs/operations/windows.md) pages.
 
 ## Upstream & License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,9 @@
 # Packer vSphere Golden Images — Documentation
 
-This directory contains the **internal** documentation site, built with
-[Zensical](https://zensical.org/). It is **not published** — build and preview
-it locally.
+This directory is the documentation site, built with
+[Zensical](https://zensical.org/) and published to
+[GitHub Pages](https://codelooks-com.github.io/packer-vsphere/). Build and
+preview it locally with the steps below.
 
 ## Development
 
@@ -51,6 +52,8 @@ Use `zensical build --clean` to rebuild from scratch.
 
 ## Hosting
 
-Intentionally **internal-only**: there is no deploy workflow and the site is
-never pushed to GitHub Pages. Share the built `site/` directory through an
-internal channel if needed, or just run `zensical serve` locally.
+Published to **GitHub Pages** at
+<https://codelooks-com.github.io/packer-vsphere/> by
+[`.github/workflows/docs.yml`](../.github/workflows/docs.yml) on every push to
+`main` that touches `docs/`. The `site/` build output stays git-ignored — Pages
+rebuilds it from source in CI. Use `zensical serve` for local preview.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,9 +1,9 @@
 # Packer vSphere Golden Images
 
-Internal documentation for **`codelooks-com/packer-vsphere`** — a fork of
-[`vmware/packer-examples-for-vsphere`](https://github.com/vmware/packer-examples-for-vsphere)
-customised to build multi-OS golden-image templates on the Talos cluster's
-**ephemeral ARC runners** (no pinned build VM).
+The **`codelooks-com/packer-vsphere`** pipeline builds multi-OS golden-image
+templates for vSphere on the Talos cluster's **ephemeral ARC runners** (no
+pinned build VM). The CI, runner image, and operational pipeline documented here
+are ours.
 
 ## What this builds
 
@@ -50,8 +50,11 @@ ci/matrix.json  ──►  build-templates.yml  ──►  ARC runner pod (packe
 - **[Operations → Rotate Credentials](runbooks/rotate-credentials.md)** — the
   credential-rotation runbook.
 
-!!! note "Fork scope"
-    Upstream community / contribution / release-notes pages are intentionally
-    omitted — this site documents *our* operational pipeline, not the upstream
-    project. Build target: vSAN Cluster · `vsanDatastore` · `VM Network` ·
-    `Templates` folder · SSO domain `core.codelooks.com`.
+!!! note "Scope & attribution"
+    This site documents *our* operational pipeline — upstream community /
+    contribution / release-notes pages are intentionally omitted. The build
+    engine derives from
+    [`vmware/packer-examples-for-vsphere`](https://github.com/vmware/packer-examples-for-vsphere)
+    (BSD-2-Clause; see [License](license.md)). Build target: vSAN Cluster ·
+    `vsanDatastore` · `VM Network` · `Templates` folder · SSO domain
+    `core.codelooks.com`.

--- a/docs/docs/operations/architecture.md
+++ b/docs/docs/operations/architecture.md
@@ -11,7 +11,7 @@ How a golden image goes from `ci/matrix.json` to a promoted vSphere template.
 | `build.sh` | this repo | Wraps `packer init/validate/build` per OS line. |
 | `packer-runner` image | `ghcr.io/codelooks-com/packer-runner` | Pinned toolchain (Packer, Ansible, govc, mise). |
 | ARC scale set `packer-vsphere` | `LukeEvansTech/talos-cluster` | Ephemeral runner pods (`min 0 / max 3`). |
-| `validate.yml` / `upload-isos.yml` | `.github/workflows` | PR validation of every entry; staging ISOs to the datastore. |
+| `validate.yml` / `upload-isos.yml` | `.github/workflows` | `packer validate` every entry (PRs + pushes to `main`); staging ISOs to the datastore. |
 
 ## The matrix
 
@@ -38,8 +38,22 @@ jq -c --arg sel "$SELECTED" \
 - **Build:** weekly, Saturday **02:00 UTC** (`build-templates.yml`), `all`
   enabled lines, `max-parallel: 2` (at most two build VMs hold a DHCP lease at
   once). Runs serialize via the `build-templates` concurrency group.
-- **ISO currency:** `check-iso-updates.yml`, Monday **06:00 UTC** — opens a PR
-  when a newer Linux ISO is published (discovery via the matrix `discover` block).
+- **ISO currency:** `check-iso-updates.yml`, Monday **06:00 UTC** — when a newer
+  Linux point release is published (discovery via the matrix `discover` block),
+  it commits the `iso_url`/`sums_url` + `iso_file` bump **straight to `main`**
+  (no PR, no approval gate) and dispatches `upload-isos` for each bumped line, so
+  the datastore is staged before Saturday's rebuild. `validate.yml` re-runs
+  `packer validate` on the push to `main`, so the bump is still checked.
+
+!!! note "GitHub scheduler caveats"
+    Neither is an approval gate, but both affect unattended runs:
+
+    - **Timing is best-effort.** Cron is frequently delayed under load — runs
+      have started hours after the nominal time. Don't rely on the exact minute.
+    - **60-day auto-disable.** GitHub disables scheduled workflows after ~60 days
+      with no repository activity; re-enable from the **Actions** tab if it
+      happens. The Monday ISO commit to `main` normally keeps the repo active
+      enough to prevent this.
 
 ## Build flow
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -1,10 +1,10 @@
 [project]
 site_name = "Packer vSphere Golden Images"
-site_description = "Internal documentation for the multi-OS golden-image pipeline (Linux + Windows) built on the Talos cluster's ARC runners."
+site_description = "Documentation for the codelooks-com multi-OS golden-image pipeline (Linux + Windows) built on the Talos cluster's ARC runners."
 site_author = "codelooks-com"
-# Internal-only site — built and previewed locally (`zensical serve`), never
-# published. site_url is a placeholder so absolute links resolve in preview.
-site_url = "http://localhost:8000/"
+# Published to GitHub Pages via .github/workflows/docs.yml. The subpath in
+# site_url is load-bearing: it sets the base URL for the project Pages site.
+site_url = "https://codelooks-com.github.io/packer-vsphere/"
 copyright = "Copyright &copy; 2026 codelooks-com"
 generator = false
 


### PR DESCRIPTION
## Summary

Publishes the docs site (previously internal-only) to **GitHub Pages** and reframes the project away from "a fork of VMware," while keeping the required BSD-2-Clause attribution.

### Publishing
- **`.github/workflows/docs.yml`** (new): builds the Zensical site on PRs (validation) and **build + deploy to Pages** on push to `main` / manual dispatch. Per-job least-privilege permissions, SHA-pinned actions, `github-pages` environment.
- **`docs/zensical.toml`**: `site_url` → `https://codelooks-com.github.io/packer-vsphere/` (project-Pages subpath is load-bearing for link resolution). Verified a clean local `zensical build` with the URL baked into output + sitemap.

### Refocus off the fork (attribution kept)
- **README / docs index / docs README**: lead as the `codelooks-com` project; upstream credit + BSD-2-Clause moved to a "Scope & attribution" note / license footer. Docs links now point at the published site; dropped "internal-only, not published" wording. `terraform-vsphere` referenced as the downstream consumer.

### Docs content
- **`operations/architecture.md`**: documents the new ISO flow (detect → commit to `main` → auto-dispatch `upload-isos`; `validate` re-runs on the push) and the GitHub scheduler caveats (best-effort timing, 60-day auto-disable).
- **`build-templates.yml`**: same scheduler caveats noted by the cron.

### After merge (manual, per agreed rollout)
1. Enable Pages (source: GitHub Actions).
2. Set the repo **About**: Website → the Pages URL; refresh description.

> Note: the `deploy` job is skipped on PRs, so this PR only runs the **build** validation; the first real deploy happens after merge once Pages is enabled.