### PR TITLE
docs: render the pipeline diagram as Mermaid

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,13 +19,20 @@ These templates are consumed downstream by `codelooks-com/terraform-vsphere`.
 
 ## How it works (at a glance)
 
-```text
-ci/matrix.json  ──►  build-templates.yml  ──►  ARC runner pod (packer-runner image)
- (one entry per          (GitHub Actions,         │
-  OS line; single         weekly cron + manual)    ├─ build.sh → packer vsphere-iso
-  source of truth)                                 ├─ install via CD (autounattend / cloud-init / kickstart)
-                                                    ├─ ansible provisioner (patches, hardening)
-                                                    └─ convert to template → promote (-prev swap)
+```mermaid
+flowchart LR
+    M["ci/matrix.json<br>one entry per OS line<br>single source of truth"]
+    W["build-templates.yml<br>GitHub Actions<br>weekly cron + manual"]
+    M --> W --> Pod
+
+    subgraph Pod["ARC runner pod · packer-runner image"]
+        direction TB
+        S1["build.sh → packer vsphere-iso"]
+        S2["install via CD<br>autounattend / cloud-init / kickstart"]
+        S3["ansible provisioner<br>patches, hardening"]
+        S4["convert to template → promote (-prev swap)"]
+        S1 --> S2 --> S3 --> S4
+    end
 ```
 
 - **`ci/matrix.json`** is the single source of truth — each OS line is one entry

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
-# Zensical documentation generator (internal docs site — built/previewed locally)
-zensical>=0.0.4
+# Zensical documentation generator. Floor at 0.0.45: it renders
+# pymdownx.superfences custom fences (Mermaid) correctly — older builds (e.g.
+# 0.0.5) silently pass ```mermaid through as a literal code block.
+zensical>=0.0.45

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -64,18 +64,28 @@ social = [
     { icon = "fontawesome/brands/github", link = "https://github.com/codelooks-com/packer-vsphere", name = "GitHub" }
 ]
 
-# Markdown extensions
-[project.markdown_extensions]
-admonition = {}
-attr_list = {}
-tables = {}
-toc = { permalink = true }
-pymdownx.highlight = {}
-pymdownx.inlinehilite = {}
-pymdownx.superfences = {}
-pymdownx.tabbed = { alternate_style = true }
-pymdownx.details = {}
-pymdownx.emoji = {}
+# Markdown extensions — one [table] header per extension (Zensical's idiom;
+# the inline `pymdownx.superfences = {…}` form silently disables the fence).
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.attr_list]
+[project.markdown_extensions.tables]
+[project.markdown_extensions.toc]
+permalink = true
+
+[project.markdown_extensions.pymdownx.highlight]
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.emoji]
+
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+
+# Mermaid: render fenced ```mermaid blocks client-side (Zensical auto-loads
+# mermaid.js when a page contains a mermaid block).
+[project.markdown_extensions.pymdownx.superfences]
+custom_fences = [
+    { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },
+]
 
 # Navigation structure
 [project.nav]


### PR DESCRIPTION
## Summary

Converts the "How it works (at a glance)" ASCII diagram on the docs homepage into a **Mermaid** flowchart, and wires up Mermaid rendering in Zensical.

### Changes
- **`index.md`**: ASCII block → Mermaid `flowchart LR` (`matrix.json` → `build-templates.yml` → ARC runner pod, with the build phases — packer / install-via-CD / ansible / convert+promote — as a top-down subgraph).
- **`zensical.toml`**: enable Mermaid via a `pymdownx.superfences` custom fence, and convert the `markdown_extensions` block to one `[table]` header per extension. This is Zensical's idiom — the inline `pymdownx.superfences = {…}` form silently disables the fence. Zensical auto-loads mermaid.js when a page contains a diagram (no extra JS config).
- **`requirements.txt`**: floor `zensical>=0.0.45`. Older builds (e.g. 0.0.5) pass ```mermaid through as a literal code block — verified 0.0.45 emits `<pre class="mermaid">` correctly.

Verified locally with zensical 0.0.45: the homepage builds with a `class="mermaid"` element and no literal fence.