### PR TITLE
docs: fix nav rendering as "none"

### DIFF
--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -18,6 +18,29 @@ repo_url = "https://github.com/codelooks-com/packer-vsphere"
 repo_name = "GitHub"
 edit_uri = "edit/main/docs/docs"
 
+# Navigation — array form. Zensical reads section titles from { "Title" = … }
+# inline tables; the [project.nav] table form renders every entry as "none".
+nav = [
+    { "Home" = "index.md" },
+    { "Getting Started" = [
+        { "Requirements" = "getting-started/requirements.md" },
+        { "Get the Project" = "getting-started/get-project.md" },
+        { "Download ISOs" = "getting-started/downloads.md" },
+        { "Privileges" = "getting-started/privileges.md" },
+        { "Configure" = "getting-started/configure.md" },
+        { "Build" = "getting-started/build.md" },
+        { "FAQ" = "getting-started/faq.md" },
+    ] },
+    { "Operations" = [
+        { "Architecture & Pipeline" = "operations/architecture.md" },
+        { "Windows Templates" = "operations/windows.md" },
+        { "Rotate Credentials" = "runbooks/rotate-credentials.md" },
+    ] },
+    { "Reference" = [
+        { "License" = "license.md" },
+    ] },
+]
+
 # Theme configuration
 [project.theme]
 name = "material"
@@ -85,25 +108,4 @@ alternate_style = true
 [project.markdown_extensions.pymdownx.superfences]
 custom_fences = [
     { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },
-]
-
-# Navigation structure
-[project.nav]
-"Home" = "index.md"
-"Getting Started" = [
-    { "Requirements" = "getting-started/requirements.md" },
-    { "Get the Project" = "getting-started/get-project.md" },
-    { "Download ISOs" = "getting-started/downloads.md" },
-    { "Privileges" = "getting-started/privileges.md" },
-    { "Configure" = "getting-started/configure.md" },
-    { "Build" = "getting-started/build.md" },
-    { "FAQ" = "getting-started/faq.md" }
-]
-"Operations" = [
-    { "Architecture & Pipeline" = "operations/architecture.md" },
-    { "Windows Templates" = "operations/windows.md" },
-    { "Rotate Credentials" = "runbooks/rotate-credentials.md" }
-]
-"Reference" = [
-    { "License" = "license.md" }
 ]


### PR DESCRIPTION
The left nav showed **none** for every top-level section. Zensical reads nav titles from an ordered `nav = [ { "Title" = … } ]` array under `[project]`, not from a `[project.nav]` table. Switched to the array form.

Verified with zensical 0.0.45: nav renders Home / Getting Started / Operations / Reference with all child pages, no `none`.