### PR TITLE
docs: correct the mise tool table in .mise.md

### DIFF
--- a/.mise.md
+++ b/.mise.md
@@ -93,7 +93,7 @@ The following tools are managed by mise (as defined in [`.mise.toml`](.mise.toml
 
 The following tools are **NOT currently managed by mise** and need to be installed via system package manager. These may be added to mise configuration in the future:
 
-- **git** (>= 2.43.0) - Should be managed by system package manager (usually pre-installed)
+- **Git** (>= 2.43.0) - Should be managed by system package manager (usually pre-installed)
 - **xorriso** (>= 1.5.6) - Linux only, install via system package manager
 - **coreutils** - macOS only, install via: `brew install coreutils`
 

--- a/.mise.md
+++ b/.mise.md
@@ -78,13 +78,16 @@ mise upgrade
 
 The following tools are managed by mise (as defined in [`.mise.toml`](.mise.toml)):
 
-| Tool      | Version | Description                              |
-|-----------|---------|------------------------------------------|
-| packer    | 1.12.0  | HashiCorp Packer                         |
-| ansible   | latest  | Automation engine (includes ansible-core 2.19.3) |
-| terraform | 1.10.0  | Infrastructure as Code tool              |
-| gomplate  | 4.3.0   | Template renderer                        |
-| jq        | 1.8.1   | Command-line JSON processor              |
+| Tool         | Version | Description                  |
+| ------------ | ------- | ---------------------------- |
+| packer       | 1.15.4  | HashiCorp Packer             |
+| ansible-core | 2.21.0  | Ansible automation engine    |
+| gomplate     | 5.1.0   | Template renderer            |
+| terraform    | 1.15.6  | Infrastructure as Code tool  |
+| jq           | 1.8.1   | Command-line JSON processor  |
+| govc         | 0.54.1  | vCenter CLI (vmware/govmomi) |
+| goss         | 0.4.9   | Post-build smoke assertions  |
+| gh           | 2.94.0  | GitHub CLI                   |
 
 ## Additional System Requirements
 
@@ -131,6 +134,7 @@ sudo dnf install xorriso
 ### Tools not found after installation
 
 Make sure you've either:
+
 1. Activated mise in your shell: `eval "$(mise activate zsh)"`
 2. Or use `mise exec --` before commands
 


### PR DESCRIPTION
The `.mise.md` *Installed Tools* table had drifted from `.mise.toml`. Corrected versions (packer 1.15.4, terraform 1.15.6, gomplate 5.1.0, ansible-core 2.21.0, jq 1.8.1) and added the three missing tools (`govc` 0.54.1, `goss` 0.4.9, `gh` 2.94.0). Now matches `.mise.toml`. Prettier-clean.