### PR TITLE
docs: refresh docs to match current state

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -27,7 +27,7 @@ jq           = "1.8.1"
 # CI/runner tooling (used by the in-cluster runner image and smoke tests)
 "aqua:vmware/govmomi/govc" = "0.54.1"  # vCenter CLI (mise id is the aqua backend, NOT bare "govc")
 goss = "0.4.9"    # post-build smoke assertions
-gh   = "2.94.0"   # GitHub CLI: open ISO-bump PRs from workflows
+gh   = "2.94.0"   # GitHub CLI: check-iso-updates dispatches upload-isos via gh
 
 # git >= 2.43.0 and xorriso >= 1.5.6 (Linux) come from the system package
 # manager / runner image, not mise.

--- a/docs/docs/getting-started/get-project.md
+++ b/docs/docs/getting-started/get-project.md
@@ -12,11 +12,11 @@ You can choose between two options to get the source code:
 === ":octicons-download-24: &nbsp; Download the Latest Release"
 
       ```shell
-      TAG_NAME=$(curl -s https://api.github.com/repos/vmware/packer-examples-for-vsphere/releases | jq  -r '.[0].tag_name')
-      TARBALL_URL=$(curl -s https://api.github.com/repos/vmware/packer-examples-for-vsphere/releases | jq  -r '.[0].tarball_url')
+      TAG_NAME=$(curl -s https://api.github.com/repos/codelooks-com/packer-vsphere/releases | jq  -r '.[0].tag_name')
+      TARBALL_URL=$(curl -s https://api.github.com/repos/codelooks-com/packer-vsphere/releases | jq  -r '.[0].tarball_url')
 
-      mkdir packer-examples-for-vsphere
-      cd packer-examples-for-vsphere
+      mkdir packer-vsphere
+      cd packer-vsphere
       curl -sL $TARBALL_URL | tar xvfz - --strip-components 1
       git init -b main
       git add .
@@ -27,12 +27,12 @@ You can choose between two options to get the source code:
 === ":octicons-repo-clone-24: &nbsp; Clone the Repository"
 
       ```shell
-      TAG_NAME=$(curl -s https://api.github.com/repos/vmware/packer-examples-for-vsphere/releases | jq -r '.[0].tag_name')
+      TAG_NAME=$(curl -s https://api.github.com/repos/codelooks-com/packer-vsphere/releases | jq -r '.[0].tag_name')
 
       BRANCH_NAME="${TAG_NAME//\//-}"
 
-      git clone https://github.com/vmware/packer-examples-for-vsphere.git
-      cd packer-examples-for-vsphere
+      git clone https://github.com/codelooks-com/packer-vsphere.git
+      cd packer-vsphere
 
       if git switch -c "$BRANCH_NAME" "$TAG_NAME"; then
             echo "Switched to new branch: $BRANCH_NAME"

--- a/docs/docs/getting-started/requirements.md
+++ b/docs/docs/getting-started/requirements.md
@@ -4,6 +4,14 @@ icon: octicons/verified-24
 
 # Environment Requirements
 
+!!! note "Upstream local-build reference"
+
+    The **Getting Started** pages cover the **local / manual** build path
+    (`./build.sh`, `./download.sh`) inherited from upstream and span more
+    operating systems than we build. Day-to-day, golden images are produced by
+    the **CI pipeline** — see
+    [Operations → Architecture & Pipeline](../operations/architecture.md).
+
 ## :octicons-cloud-24: &nbsp; Platform
 
 The project is tested on the following platforms:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -58,9 +58,9 @@ flowchart LR
   credential-rotation runbook.
 
 !!! note "Scope & attribution"
-    This site documents *our* operational pipeline — upstream community /
-    contribution / release-notes pages are intentionally omitted. The build
-    engine derives from
+    **Operations** and **Runbooks** document *our* CI pipeline; **Getting
+    Started** is the upstream local-build reference and covers more than we
+    build. The build engine derives from
     [`vmware/packer-examples-for-vsphere`](https://github.com/vmware/packer-examples-for-vsphere)
     (BSD-2-Clause; see [License](license.md)). Build target: vSAN Cluster ·
     `vsanDatastore` · `VM Network` · `Templates` folder · SSO domain

--- a/docs/docs/runbooks/rotate-credentials.md
+++ b/docs/docs/runbooks/rotate-credentials.md
@@ -29,7 +29,7 @@ export GOVC_URL="https://$(op read 'op://Talos/vsphere-packer/VSPHERE_ENDPOINT')
 export GOVC_USERNAME="$(op read 'op://Talos/vsphere-packer/VSPHERE_USERNAME')"
 export GOVC_PASSWORD="$(op read 'op://Talos/vsphere-packer/VSPHERE_PASSWORD')"
 export GOVC_INSECURE=true
-mise exec "aqua:vmware/govmomi/govc@0.49.0" -- \
+mise exec "aqua:vmware/govmomi/govc@0.54.1" -- \
   govc sso.user.update -p "$NEW_PW" svc-packer
 op item edit vsphere-packer --vault Talos "VSPHERE_PASSWORD=$NEW_PW"
 unset NEW_PW
@@ -96,7 +96,8 @@ kubectl annotate externalsecret -n actions-runner-system packer-runner \
 
 ## Old-ISO cleanup (housekeeping, not a credential)
 
-After an ISO bump PR merges and the new ISO is staged, delete the old one:
+After an ISO bump lands on `main` and `upload-isos` has staged the new ISO
+(both automated by `check-iso-updates`), delete the old one:
 
 ```bash
 govc datastore.ls -ds vsanDatastore 'iso/linux/<os>/<ver>/amd64'


### PR DESCRIPTION
Holistic accuracy pass after the ISO-flow / Pages-publishing / de-fork changes, instead of one-off fixes.

### Our docs (factual fixes)
- **runbooks/rotate-credentials.md** — ISO bumps now land on `main` (no PR) and `upload-isos` is auto-dispatched by `check-iso-updates`; bumped the `govc` example to the pinned **0.54.1**.
- **.mise.toml** — `gh` comment now reflects that `check-iso-updates` dispatches `upload-isos` (it no longer opens ISO-bump PRs).

### Getting Started (reframe + fix wrong-repo link)
- **get-project.md** — clone/download now point at **codelooks-com/packer-vsphere** (was the upstream `vmware/packer-examples-for-vsphere`).
- **requirements.md** — added a banner: Getting Started is the **upstream local-build reference** (covers more OSes than we build); day-to-day builds run via CI → Operations.
- **index.md** — reworded the scope note to match (Operations/Runbooks document our pipeline; Getting Started is the upstream local-build reference).

Verified with a clean `zensical build` (0.0.45): builds, banner renders, nav unaffected.

> Note: the rest of `getting-started/*` (configure/build/downloads/faq/privileges) remains the upstream local-build how-to by design — the banner now frames it correctly rather than rewriting it.