### PR TITLE
docs: refresh CLAUDE.md after recent cleanups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,13 +87,13 @@ blocks and other `pymdownx.superfences` custom fences as literal code blocks.
   house-style lint: `build.sh`, `download.sh`, `config.sh`, `set-envvars.sh`,
   `config/`, `*.pkrtpl.hcl`, and `docs/` (the docs site is validated by
   `zensical build`, not super-linter).
-- **super-linter only checks changed, non-excluded files.** Root markdown
+- **super-linter only checks changed, non-excluded files.** Root Markdown
   (`README.md`, `.mise.md`) gets prettier **and** textlint terminology rules
   (e.g. `Git`, not `git`).
 - **`gh` may resolve to the upstream `vmware` remote** — pass
   `-R codelooks-com/packer-vsphere` or run `gh repo set-default`.
 - **Scheduled workflows**: GitHub cron is best-effort (often delayed) and
-  auto-disables after ~60 days of repo inactivity.
+  auto-disables after ~60 days of repository inactivity.
 - **Docs scope**: `docs/docs/operations/` + `runbooks/` document _our_ pipeline;
   `getting-started/` is the upstream local-build reference.
 - **Windows builds** have hard-won, documented gotchas (`vm_inst_os_eval=false`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ cd tests/network && bats test            # also: cd tests/storage && bats test
 
 python3 ci/scripts/check_iso_updates.py  # detect Linux ISO bumps locally
 
-# Docs (Zensical — NOT the stale mkdocs Makefile targets)
+# Docs (Zensical site under docs/; make docs-serve / make docs-build wrap these)
 cd docs && pip install -r requirements.txt && zensical serve   # preview
 cd docs && zensical build                                       # build to docs/site
 
@@ -85,10 +85,8 @@ blocks and other `pymdownx.superfences` custom fences as literal code blocks.
 
 - **Vendored upstream files carry minimal surgical diffs** and are excluded from
   house-style lint: `build.sh`, `download.sh`, `config.sh`, `set-envvars.sh`,
-  `config/`, `*.tmpl`, `*.pkrtpl.hcl`, and `docs/` (the docs site is validated by
-  `zensical build`, not super-linter). The `Makefile` `docs-*` targets are stale
-  upstream (they use `mkdocs` + a missing requirements file) — use the Zensical
-  commands above.
+  `config/`, `*.pkrtpl.hcl`, and `docs/` (the docs site is validated by
+  `zensical build`, not super-linter).
 - **super-linter only checks changed, non-excluded files.** Root markdown
   (`README.md`, `.mise.md`) gets prettier **and** textlint terminology rules
   (e.g. `Git`, not `git`).


### PR DESCRIPTION
Keeps CLAUDE.md accurate after #65 (Makefile → Zensical) and #66 (GitLab CI removed):

- The `Makefile` `docs-*` targets are no longer stale — they drive Zensical now, so note `make docs-serve` / `make docs-build` wrap the docs commands.
- Dropped `*.tmpl` from the vendored-files lint-exclusion list (`build-ci.tmpl` was removed with the GitLab CI scaffolding; no `.tmpl` files remain).