### PR TITLE
chore(renovate): standardize on shared LukeEvansTech/renovate-config preset

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>LukeEvansTech/renovate-config"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
Adopts the shared house Renovate standard.

- `extends: ["github>LukeEvansTech/renovate-config"]` (covers config:recommended, GitHub-Action + container digest pinning, Copilot reviewer, dependencies/security labels, Europe/London timezone, narrow GH-Actions automerge).
- Migrated to `.renovaterc.json5` for fleet consistency.
- Validated with `renovate-config-validator` (renovate@latest).

Terraform provider pinning is unchanged (constraint + `.terraform.lock.hcl` hashes — providers have no SHA). Config-only.