### PR TITLE
fix(renovate): format .renovaterc.json5 to prettier json5 style

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>LukeEvansTech/renovate-config"]
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>LukeEvansTech/renovate-config"],
 }


### PR DESCRIPTION
## Why

The Lint workflow has been failing on `main` since #69 (`abac851`):

```
##[group]JSONC_PRETTIER
[ERROR]   Errors found in JSONC_PRETTIER
[warn] .renovaterc.json5
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
```

#69 renamed `renovate.json` → `.renovaterc.json5` but kept the standard-JSON
layout (quoted keys, no trailing comma). super-linter runs prettier with the
**json5 parser** inferred from the `.json5` extension, which wants **unquoted
keys + a trailing comma**.

## Fix

Ran `prettier --write .renovaterc.json5`. The result now passes
`prettier --check` and matches the rest of the fleet
(`LukeEvansTech/talos-cluster`, `renovate-config`).

```json5
{
  $schema: "https://docs.renovatebot.com/renovate-schema.json",
  extends: ["github>LukeEvansTech/renovate-config"],
}
```

Config-only; no Renovate behavior change.