### PR TITLE
docs: note Renovate json5/prettier rule and .mise.md sync in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,9 @@ digest-pinned and runs as an ARC scale-set pod defined in
 `LukeEvansTech/talos-cluster` (min 0 / max 3). **`.mise.toml` is the single
 source of truth for tool versions** (packer, ansible-core, gomplate, terraform,
 jq, govc, goss, gh) and pins the runner image too — keep them in lockstep.
-Install locally with `mise install`.
+Install locally with `mise install`. When a version changes (e.g. Renovate
+bumps a tool), also update the `.mise.md` table by hand — super-linter only
+lints changed files, so it will not flag the drift.
 
 ## Two config trees — do not confuse
 
@@ -90,6 +92,15 @@ blocks and other `pymdownx.superfences` custom fences as literal code blocks.
 - **super-linter only checks changed, non-excluded files.** Root Markdown
   (`README.md`, `.mise.md`) gets prettier **and** textlint terminology rules
   (e.g. `Git`, not `git`).
+- **Renovate** (`.renovaterc.json5`) extends the shared
+  `github>LukeEvansTech/renovate-config` preset and is written in `json5`.
+  super-linter lints it through prettier's json5 parser (inferred from the
+  extension), which wants **unquoted keys + a trailing comma** — run
+  `prettier --write .renovaterc.json5` after editing, or `JSONC_PRETTIER`
+  fails. The preset enables `docker:pinDigests`; the self-built
+  `ghcr.io/codelooks-com/packer-runner` image is excluded via `packageRules`
+  because it is a build/push target, not a pulled dependency (a digest there
+  would make `${IMAGE}:latest` in `build-runner-image.yml` an invalid ref).
 - **`gh` may resolve to the upstream `vmware` remote** — pass
   `-R codelooks-com/packer-vsphere` or run `gh repo set-default`.
 - **Scheduled workflows**: GitHub cron is best-effort (often delayed) and


### PR DESCRIPTION
Records two gotchas surfaced by this week's CI fixes (#72, #70, #68):

- **`.renovaterc.json5` is json5.** super-linter lints it through prettier's
  json5 parser (inferred from the extension), which wants unquoted keys + a
  trailing comma. Edit then `prettier --write .renovaterc.json5`, or
  `JSONC_PRETTIER` fails (root cause of the #69 breakage).
- The self-built `ghcr.io/codelooks-com/packer-runner` image is excluded from
  `docker:pinDigests` via `packageRules` — it's a build/push target, so a
  digest would make `${IMAGE}:latest` invalid.
- Bumping a tool in `.mise.toml` also needs a manual `.mise.md` table update;
  super-linter only lints changed files, so the drift wouldn't be caught.

Docs-only.