### PR TITLE
docs(mise): sync .mise.md table with Renovate tool bumps

### DIFF
--- a/.mise.md
+++ b/.mise.md
@@ -82,12 +82,12 @@ The following tools are managed by mise (as defined in [`.mise.toml`](.mise.toml
 | ------------ | ------- | ---------------------------- |
 | packer       | 1.15.4  | HashiCorp Packer             |
 | ansible-core | 2.21.1  | Ansible automation engine    |
-| gomplate     | 5.1.0   | Template renderer            |
-| terraform    | 1.15.6  | Infrastructure as Code tool  |
-| jq           | 1.8.1   | Command-line JSON processor  |
-| govc         | 0.54.1  | vCenter CLI (vmware/govmomi) |
+| gomplate     | 5.2.0   | Template renderer            |
+| terraform    | 1.15.8  | Infrastructure as Code tool  |
+| jq           | 1.8.2   | Command-line JSON processor  |
+| govc         | 0.55.1  | vCenter CLI (vmware/govmomi) |
 | goss         | 0.4.9   | Post-build smoke assertions  |
-| gh           | 2.95.0  | GitHub CLI                   |
+| gh           | 2.96.0  | GitHub CLI                   |
 
 ## Additional System Requirements
 


### PR DESCRIPTION
Syncs the hand-maintained `.mise.md` version table with the `.mise.toml` bumps from Renovate PRs #76–#87 (gomplate, terraform, jq, govc, gh). Renovate does not touch `.mise.md` and super-linter only lints changed files, so this drift would otherwise go unflagged (per CLAUDE.md). Verified locally: super-linter v8.6.0 markdownlint + prettier + textlint all pass on `.mise.md`.