### PR TITLE
ci(build): alert on scheduled failure + fail fast on missing pywinrm

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -94,6 +94,24 @@ jobs:
         with:
           persist-credentials: false
 
+      # Ansible's WinRM connection plugin imports pywinrm on the control node
+      # (this runner) using ansible's OWN interpreter. If it's missing, the build
+      # fails ~7 min into provisioning with a cryptic "No module named 'winrm'"
+      # (Linux uses SSH — unaffected). Assert it up front, via the same venv
+      # python ansible runs under, so a bad runner image fails in seconds with a
+      # clear message instead of deep in a Packer/Ansible trace. See
+      # runner/Dockerfile (pywinrm install) and docs/docs/operations/windows.md.
+      - name: Preflight WinRM control-node deps (Windows only)
+        if: matrix.os == 'Windows'
+        run: |
+          set -euo pipefail
+          py="$(dirname "$(dirname "$(mise which ansible)")")/bin/python"
+          if ! "${py}" -c "import winrm" 2>/dev/null; then
+            echo "::error::pywinrm not importable by ansible (${py}). The packer-runner image is missing the Windows control-node dependency — rebuild it (runner/Dockerfile) and bump the digest in talos-cluster." >&2
+            exit 1
+          fi
+          echo "pywinrm OK (${py})"
+
       - name: Build ${{ matrix.dist }} ${{ matrix.version }}
         env:
           BUILD_OS: ${{ matrix.os }}
@@ -205,3 +223,51 @@ jobs:
           path: packer-build.log
           if-no-files-found: warn
           retention-days: 7
+
+  # Unattended failure alerting. The weekly build is the whole point of this
+  # pipeline and a red scheduled run is otherwise silent — no reviewer, no PR, so
+  # a break can sit unnoticed for weeks (it did: the 2026-06 Windows outage). On
+  # a SCHEDULED failure (plan or any build leg), open — or comment on an existing
+  # — GitHub issue assigned to the maintainer; the assignment emails them. Manual
+  # dispatches are skipped: those are already being watched.
+  notify:
+    needs: [plan, build]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: read
+    steps:
+      - name: Open or update the build-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # The run is still in progress (this job is running), but the build
+          # legs have already reported their conclusions.
+          failed="$(gh run view "${GITHUB_RUN_ID}" -R "${GITHUB_REPOSITORY}" \
+            --json jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')"
+          [ -n "${failed}" ] || failed="(see run for details)"
+          body="The scheduled weekly build-templates run failed.
+
+          Failed legs: ${failed}
+          Run: ${RUN_URL}
+
+          Opened automatically; close once the weekly build is green again."
+          # Best-effort label so these are filterable; harmless if it exists.
+          gh label create ci-failure -R "${GITHUB_REPOSITORY}" \
+            --color d73a4a --description "Automated CI failure report" 2>/dev/null || true
+          # Dedup by the ci-failure label: comment on the open issue if one is
+          # already tracking the outage, else open a fresh one and assign it.
+          existing="$(gh issue list -R "${GITHUB_REPOSITORY}" --state open \
+            --label ci-failure --json number --jq '.[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" -R "${GITHUB_REPOSITORY}" --body "${body}"
+            echo "Commented on existing issue #${existing}"
+          else
+            gh issue create -R "${GITHUB_REPOSITORY}" \
+              --title "Weekly template build failed" \
+              --assignee LukeEvansTech --label ci-failure --body "${body}"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,13 @@ more OSes; the matrix is what we actually build.
   job filters the matrix; a `build` job on the self-hosted `packer-vsphere` ARC
   runner runs `build.sh --ci` → `packer vsphere-iso` → Ansible → converts the VM
   to `<base>-build` → **promote** renames it to the stable `<base>` Terraform
-  clones and rolls the prior generation to `<base>-prev` (success-only).
+  clones and rolls the prior generation to `<base>-prev` (success-only). Windows
+  legs run a **preflight** that asserts Ansible can import `winrm` before Packer
+  starts — it fails fast when the runner image is missing the control-node
+  pywinrm dependency (the 2026-06 outage) instead of ~7 min into provisioning. A
+  `notify` job opens (or comments on) a `ci-failure` GitHub issue assigned to the
+  maintainer on **scheduled** failures — the assignment emails an alert; manual
+  dispatches are exempt.
 - **`check-iso-updates.yml`** — weekly (Mon 06:00 UTC). `ci/scripts/check_iso_updates.py`
   detects new Linux point releases; the workflow validates the bump inline
   (`packer fmt`/`packer validate`, mirroring `validate.yml`), then **opens a PR

--- a/docs/docs/operations/windows.md
+++ b/docs/docs/operations/windows.md
@@ -38,12 +38,23 @@ doesn't re-discover them.
    screen forever, surfacing as *"timeout waiting for IP"*. Set it in each
    `ci/config/windows-*.pkrvars.hcl`.
 
-2. **The runner image must be pinned to an immutable digest.** pywinrm is
-   pip-installed into Ansible's venv as a post-`mise install` Docker layer. With
-   a mutable `:latest` tag and no `imagePullPolicy`, ARC nodes can run a *stale
-   cached* image whose venv lacks pywinrm → Ansible fails with
-   *"No module named 'winrm'"*. The image is digest-pinned in the talos-cluster
-   helmrelease.
+2. **pywinrm on the control node — a pinned digest is necessary but not
+   sufficient.** pywinrm is pip-installed into Ansible's own venv as a
+   post-`mise install` Docker layer; Ansible's WinRM connection plugin imports it
+   at runtime. If it is missing, every Windows leg fails ~7 min in with *"No
+   module named 'winrm'"* (Linux uses SSH — unaffected). There are two
+   independent ways it goes missing, each with its own defense:
+   - **Stale cache** — a mutable `:latest` with no `imagePullPolicy` lets ARC
+     nodes run an old image whose venv lacks pywinrm. Fixed by digest-pinning the
+     image in the talos-cluster helmrelease.
+   - **A pinned-but-broken image** — the 2026-06 outage: the pinned image *itself*
+     lacked a working pywinrm (a `mise`/pipx venv reshuffle orphaned the graft),
+     so the pin faithfully served a broken image and all Windows builds were red
+     for two weeks. Now guarded by (a) installing pywinrm via the venv's own
+     `python` in `runner/Dockerfile` (robust against shim/shebang drift) and
+     (b) a **Preflight** step in `build-templates.yml` that imports `winrm`
+     through Ansible's real interpreter before Packer starts — failing in seconds
+     with a clear message instead of deep in a provisioning trace.
 
 3. **`ansible_shell_type: cmd`** (set in `ansible/windows-playbook.yml`).
    ansible-core 2.21 + pywinrm 0.5 default the WinRM shell to `powershell`, which

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -37,11 +37,21 @@ RUN --mount=type=secret,id=github_token,mode=0444 \
  && mise install \
  && mise reshim
 
-# Inject pywinrm into ansible's own interpreter (the mise/pipx venv — NOT the
-# system python3) so the WinRM connection plugin can import it at runtime.
-RUN ANSIBLE_PY="$(sed -n '1s/^#!//p' "$(mise which ansible)")" \
- && "$ANSIBLE_PY" -m pip install --no-cache-dir pywinrm \
- && "$ANSIBLE_PY" -c "import winrm"
+# Install pywinrm into ansible-core's OWN venv (the mise/pipx interpreter, NOT
+# system python3) so ansible's WinRM connection plugin can import it at runtime.
+# This is a control-node dependency: without it every Windows build fails ~7 min
+# into provisioning with "No module named 'winrm'" (Linux uses SSH — unaffected;
+# this guards the 2026-06 Windows outage, see docs/docs/operations/windows.md).
+#
+# Resolve the venv from the real ansible binary (mise which bypasses shims) via
+# its parent dir, and drive pip/verify through that venv's python directly —
+# more robust than parsing the script shebang, which breaks on a '/usr/bin/env'
+# shebang or a shim wrapper. build-templates.yml re-checks this same import at
+# run time (Preflight step) so a future venv reshuffle can't silently orphan
+# pywinrm again.
+RUN ANSIBLE_VENV="$(dirname "$(dirname "$(mise which ansible)")")" \
+ && "${ANSIBLE_VENV}/bin/python" -m pip install --no-cache-dir pywinrm \
+ && "${ANSIBLE_VENV}/bin/python" -c "import winrm"
 
 # Install the ansible galaxy collections the playbooks require.
 # linux-requirements.yml + windows-requirements.yml (incl. ansible.windows) are


### PR DESCRIPTION
## Why

The weekly `build-templates` run was **red for two consecutive Saturdays** (2026-06-20, -27) — all three Windows legs failed on `No module named 'winrm'` (Ansible's WinRM connection plugin couldn't import `pywinrm` on the control-node runner; Linux uses SSH and was unaffected). **Nobody was alerted.** It self-healed only when a routine Renovate digest bump (2026-06-28, #3205 in talos-cluster) happened to ship a rebuilt runner image. `windows.md` gotcha #2 already flagged this class of failure, but its only defense — digest pinning — proved insufficient: the *pinned* image itself carried a broken `pywinrm`.

## What

Three independent defenses so this surfaces fast and loud:

- **`notify` job (alerting)** — on a **scheduled** failure (plan or any build leg), open/comment a `ci-failure` GitHub issue assigned to the maintainer; the assignment emails an alert. Manual dispatches are exempt (already watched). A silent weekly build is the real problem this fixes.
- **Windows preflight** — assert Ansible can `import winrm` via its **real venv python** before Packer starts, so a bad runner image fails in seconds with a clear message instead of ~7 min into provisioning.
- **Runner image hardening** — install `pywinrm` through the venv's own `python` (derived from the ansible binary's parent dir) rather than parsing its shebang — robust against a `mise`/pipx venv reshuffle silently orphaning the graft.

## Docs

- `windows.md` gotcha #2 rewritten: *a pinned digest is necessary but not sufficient* — documents both failure modes (stale cache / pinned-but-broken) and their defenses.
- `CLAUDE.md` build-templates bullet notes the preflight + alerting.

## Verified

- super-linter v8.6.0 (local, real config): hadolint / actionlint / zizmor / markdownlint / textlint / yamllint all clean on changed files.
- `zensical build` — no issues.