### PR TITLE
fix(runner): resolve ansible interpreter via shebang, not venv path

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -97,15 +97,16 @@ jobs:
       # Ansible's WinRM connection plugin imports pywinrm on the control node
       # (this runner) using ansible's OWN interpreter. If it's missing, the build
       # fails ~7 min into provisioning with a cryptic "No module named 'winrm'"
-      # (Linux uses SSH — unaffected). Assert it up front, via the same venv
-      # python ansible runs under, so a bad runner image fails in seconds with a
-      # clear message instead of deep in a Packer/Ansible trace. See
-      # runner/Dockerfile (pywinrm install) and docs/docs/operations/windows.md.
+      # (Linux uses SSH — unaffected). Assert it up front, via the same interpreter
+      # ansible runs under (its console-script shebang — the mise/pipx install dir
+      # has no sibling python), so a bad runner image fails in seconds with a clear
+      # message instead of deep in a Packer/Ansible trace. Mirrors the install in
+      # runner/Dockerfile; see docs/docs/operations/windows.md.
       - name: Preflight WinRM control-node deps (Windows only)
         if: matrix.os == 'Windows'
         run: |
           set -euo pipefail
-          py="$(dirname "$(dirname "$(mise which ansible)")")/bin/python"
+          py="$(sed -n '1s/^#!//p' "$(mise which ansible)")"
           if ! "${py}" -c "import winrm" 2>/dev/null; then
             echo "::error::pywinrm not importable by ansible (${py}). The packer-runner image is missing the Windows control-node dependency — rebuild it (runner/Dockerfile) and bump the digest in talos-cluster." >&2
             exit 1

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -37,21 +37,21 @@ RUN --mount=type=secret,id=github_token,mode=0444 \
  && mise install \
  && mise reshim
 
-# Install pywinrm into ansible-core's OWN venv (the mise/pipx interpreter, NOT
+# Install pywinrm into ansible-core's OWN interpreter (the mise/pipx venv, NOT
 # system python3) so ansible's WinRM connection plugin can import it at runtime.
 # This is a control-node dependency: without it every Windows build fails ~7 min
 # into provisioning with "No module named 'winrm'" (Linux uses SSH — unaffected;
-# this guards the 2026-06 Windows outage, see docs/docs/operations/windows.md).
+# see the 2026-06 Windows outage in docs/docs/operations/windows.md).
 #
-# Resolve the venv from the real ansible binary (mise which bypasses shims) via
-# its parent dir, and drive pip/verify through that venv's python directly —
-# more robust than parsing the script shebang, which breaks on a '/usr/bin/env'
-# shebang or a shim wrapper. build-templates.yml re-checks this same import at
-# run time (Preflight step) so a future venv reshuffle can't silently orphan
-# pywinrm again.
-RUN ANSIBLE_VENV="$(dirname "$(dirname "$(mise which ansible)")")" \
- && "${ANSIBLE_VENV}/bin/python" -m pip install --no-cache-dir pywinrm \
- && "${ANSIBLE_VENV}/bin/python" -c "import winrm"
+# The interpreter is the ansible console-script's shebang. mise installs
+# ansible-core via its pipx backend, whose install dir holds the entry scripts
+# but NO sibling python (installs/ansible-core/<v>/bin/ has ansible, not
+# python) — so the shebang, an absolute venv python path, is the only reliable
+# pointer. build-templates.yml re-checks this exact import at run time (the
+# Preflight step) as the real safety net against a broken deployed image.
+RUN ANSIBLE_PY="$(sed -n '1s/^#!//p' "$(mise which ansible)")" \
+ && "$ANSIBLE_PY" -m pip install --no-cache-dir pywinrm \
+ && "$ANSIBLE_PY" -c "import winrm"
 
 # Install the ansible galaxy collections the playbooks require.
 # linux-requirements.yml + windows-requirements.yml (incl. ansible.windows) are


### PR DESCRIPTION
## Why

Follow-up to #91. That PR's `(c)` runner-image change and `(b)` preflight both resolved ansible's interpreter by `dirname/dirname "$(mise which ansible)" + /bin/python` — which is **wrong**: mise installs ansible-core via its **pipx** backend, and the real venv is one level deeper:

```
installs/ansible-core/2.21.1/venvs/ansible-core/bin/python   ← actual
installs/ansible-core/2.21.1/bin/python                      ← what #91 looked for (doesn't exist)
```

So the runner-image build failed at the pywinrm verify (`exit 127`, [run 29259100286](https://github.com/codelooks-com/packer-vsphere/actions/runs/29259100286)) and the Windows preflight would have failed every run. The deployed image (`4c5e182`) is untouched and still works — but the broken preflight is on `main`, so this closes it before Saturday's rebuild.

## Fix

Restore the **proven** shebang-based resolution — the ansible console-script's shebang is an absolute venv python path — in both the Dockerfile install and the preflight:

```
ANSIBLE_PY="$(sed -n '1s/^#!//p' "$(mise which ansible)")"
```

This is the exact method that built every working image since the runner was introduced (#16).

## Verified

- **Local `docker buildx build` (linux/amd64) of the full runner image → exit 0**; the pywinrm layer installs `pywinrm-0.5.0` and `import winrm` passes.
- super-linter v8.6.0: hadolint / actionlint / zizmor / yaml all clean.