### PR TITLE
feat(windows): fleet-wide security baseline (WinRM HTTPS + PowerShell 7)

### DIFF
--- a/ansible/roles/harden/defaults/main.yml
+++ b/ansible/roles/harden/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+# Fleet-wide security baseline — tunables.
+#
+# These are defaults (not vars) so a per-line pkrvars or an --extra-vars can
+# override them without editing the role.
+
+# --- PowerShell 7 -----------------------------------------------------------
+# Windows Server 2025 and Windows 11 still ship Windows PowerShell 5.1 only.
+# Modern tooling increasingly requires 7+ (e.g. Veeam 13's PowerShell module).
+#
+# Version and checksum are a matched pair — bump BOTH together. Get the hash
+# with:
+#   curl -sLO https://github.com/PowerShell/PowerShell/releases/download/v<X>/PowerShell-<X>-win-x64.msi
+#   sha256sum PowerShell-<X>-win-x64.msi
+harden_powershell_version: 7.6.3
+harden_powershell_msi_sha256: 4f574fddb567f4d0756094424a1e4e2b2bbdde21de9f0965c0f988d24dc658e4
+
+harden_powershell_msi_url: >-
+  https://github.com/PowerShell/PowerShell/releases/download/v{{ harden_powershell_version }}/PowerShell-{{ harden_powershell_version }}-win-x64.msi
+harden_powershell_msi_path: 'C:\Windows\Temp\PowerShell-{{ harden_powershell_version }}-win-x64.msi'
+harden_powershell_exe: 'C:\Program Files\PowerShell\7\pwsh.exe'
+
+# --- WinRM over HTTPS -------------------------------------------------------
+harden_winrm_https_port: 5986
+
+# Certificate lifetime, and how close to expiry the first-boot script renews.
+harden_winrm_cert_validity_years: 2
+harden_winrm_cert_renew_within_days: 30
+
+# Tear down the plaintext 5985 listener at first boot, once HTTPS is up.
+#
+# Left FALSE deliberately. Packer's own provisioning — including the Ansible
+# run that installs this very script — connects over 5985, and vSphere guest
+# customisation may re-run WinRM configuration on clone. Disabling plaintext is
+# a deploy-time decision for per-VM Ansible, not something to bake into a
+# template that every Windows VM in the fleet is cloned from.
+#
+# Flip to true only once you have confirmed every consumer speaks HTTPS.
+harden_winrm_disable_http_listener: false
+
+# Where template-owned scripts and their logs live on the guest.
+harden_script_dir: 'C:\ProgramData\PackerTemplate'

--- a/ansible/roles/harden/files/Initialize-WinRMHttps.ps1
+++ b/ansible/roles/harden/files/Initialize-WinRMHttps.ps1
@@ -1,0 +1,205 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Ensure a WinRM HTTPS listener on this machine, backed by a self-signed
+    certificate that matches the machine's current name.
+
+.DESCRIPTION
+    Baked into the vSphere golden template by ansible/roles/harden and run at
+    every boot (plus daily) by the 'Initialize-WinRMHttps' scheduled task.
+
+    Why this runs per-machine instead of being configured once at build time:
+    a certificate generated during the Packer build would carry the template
+    VM's name. Every VM cloned from that template is renamed by vSphere guest
+    customisation, so the baked certificate would be wrong everywhere, and all
+    clones would share one private key. Generating on the guest fixes both.
+
+    The script is idempotent. Once a listener exists whose certificate matches
+    the current hostname and is not near expiry, it does nothing.
+
+    The plaintext listener on 5985 is left alone unless -DisableHttpListener is
+    passed: Packer's own provisioning connects over it, and removing it is a
+    deploy-time decision rather than a template-wide one.
+
+.NOTES
+    Exits 0 even on failure. This runs at boot; a hardening step must never
+    block a machine from starting. Failures are recorded in the log file.
+#>
+[CmdletBinding()]
+param(
+    [int]$Port = 5986,
+    [int]$CertValidityYears = 2,
+    [int]$RenewWithinDays = 30,
+    [switch]$DisableHttpListener
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Certificates this script owns. Used to distinguish ours from any operator- or
+# application-installed certificate, so cleanup never deletes someone else's.
+$CertFriendlyName = 'Packer template WinRM HTTPS'
+$LogPath = Join-Path $PSScriptRoot 'Initialize-WinRMHttps.log'
+
+function Write-BootLog {
+    param([string]$Message, [string]$Level = 'INFO')
+    $line = '{0} [{1}] {2}' -f (Get-Date -Format 's'), $Level, $Message
+    Write-Output $line
+    # Best-effort file logging; never let a logging failure abort the boot script.
+    Add-Content -Path $LogPath -Value $line -ErrorAction SilentlyContinue
+}
+
+function Get-TargetDnsName {
+    <# Names the certificate must cover: short name always, FQDN when domain-joined. #>
+    $names = @($env:COMPUTERNAME)
+    try {
+        $cs = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
+        if ($cs.PartOfDomain -and $cs.Domain) {
+            $names += ('{0}.{1}' -f $env:COMPUTERNAME, $cs.Domain)
+        }
+    } catch {
+        Write-BootLog "Could not determine domain membership: $($_.Exception.Message)" 'WARN'
+    }
+    , ($names | Select-Object -Unique)
+}
+
+function Get-HttpsListener {
+    Get-ChildItem -Path WSMan:\localhost\Listener -ErrorAction SilentlyContinue |
+        Where-Object { $_.Keys -contains 'Transport=HTTPS' }
+}
+
+function Test-ListenerCurrent {
+    <# True when the existing listener's certificate covers this hostname and is not near expiry. #>
+    param($Listener, [string[]]$RequiredNames, [int]$RenewWithinDays)
+
+    if (-not $Listener) { return $false }
+
+    $thumbprint = (Get-ChildItem -Path "WSMan:\localhost\Listener\$($Listener.Name)" |
+        Where-Object { $_.Name -eq 'CertificateThumbprint' }).Value
+    if ([string]::IsNullOrWhiteSpace($thumbprint)) { return $false }
+
+    $cert = Get-Item -Path "Cert:\LocalMachine\My\$($thumbprint -replace '\s', '')" -ErrorAction SilentlyContinue
+    if (-not $cert) {
+        Write-BootLog 'Listener references a certificate that is no longer in the store.' 'WARN'
+        return $false
+    }
+
+    if ($cert.NotAfter -le (Get-Date).AddDays($RenewWithinDays)) {
+        Write-BootLog "Certificate expires $($cert.NotAfter) - inside the $RenewWithinDays day renewal window."
+        return $false
+    }
+
+    $certNames = @($cert.DnsNameList | ForEach-Object { $_.Unicode })
+    foreach ($required in $RequiredNames) {
+        if ($certNames -notcontains $required) {
+            Write-BootLog "Certificate does not cover '$required' (has: $($certNames -join ', ')) - machine was likely renamed."
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Set-HttpsListener {
+    param(
+        [string[]]$DnsName,
+        [int]$ListenerPort,
+        [int]$ValidityYears
+    )
+
+    Write-BootLog "Creating a self-signed certificate for: $($DnsName -join ', ')"
+    $cert = New-SelfSignedCertificate `
+        -DnsName $DnsName `
+        -CertStoreLocation 'Cert:\LocalMachine\My' `
+        -FriendlyName $CertFriendlyName `
+        -NotAfter (Get-Date).AddYears($ValidityYears) `
+        -KeyExportPolicy NonExportable `
+        -KeyUsage DigitalSignature, KeyEncipherment `
+        -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.1')  # EKU: serverAuth
+
+    Write-BootLog "Certificate thumbprint $($cert.Thumbprint), valid until $($cert.NotAfter)."
+
+    # Remove any existing HTTPS listener before rebinding - a listener's
+    # certificate cannot be swapped in place.
+    Get-HttpsListener | ForEach-Object {
+        Write-BootLog "Removing existing HTTPS listener '$($_.Name)'."
+        Remove-Item -Path "WSMan:\localhost\Listener\$($_.Name)" -Recurse -Force
+    }
+
+    New-Item -Path WSMan:\localhost\Listener `
+        -Transport HTTPS -Address * -Port $ListenerPort `
+        -CertificateThumbPrint $cert.Thumbprint -Force | Out-Null
+    Write-BootLog "HTTPS listener bound on port $ListenerPort."
+
+    # Drop superseded certificates this script created previously.
+    Get-ChildItem -Path Cert:\LocalMachine\My |
+        Where-Object { $_.FriendlyName -eq $CertFriendlyName -and $_.Thumbprint -ne $cert.Thumbprint } |
+        ForEach-Object {
+            Write-BootLog "Removing superseded certificate $($_.Thumbprint)."
+            Remove-Item -Path $_.PSPath -Force
+        }
+}
+
+function Set-FirewallRule {
+    param([int]$ListenerPort)
+
+    $name = 'WINRM-HTTPS-In-TCP'
+    if (Get-NetFirewallRule -Name $name -ErrorAction SilentlyContinue) { return }
+
+    New-NetFirewallRule -Name $name `
+        -DisplayName 'Windows Remote Management (HTTPS-In)' `
+        -Description 'Inbound rule for WinRM over HTTPS. Added by the Packer template security baseline.' `
+        -Group 'Windows Remote Management' `
+        -Protocol TCP -LocalPort $ListenerPort -Direction Inbound -Action Allow -Profile Any | Out-Null
+    Write-BootLog "Firewall rule '$name' created for TCP/$ListenerPort."
+}
+
+function Remove-HttpListener {
+    $http = Get-ChildItem -Path WSMan:\localhost\Listener -ErrorAction SilentlyContinue |
+        Where-Object { $_.Keys -contains 'Transport=HTTP' }
+    if (-not $http) { return }
+
+    # Refuse to remove plaintext unless HTTPS is actually listening, otherwise
+    # this locks the machine out of remote management entirely.
+    if (-not (Get-HttpsListener)) {
+        Write-BootLog 'Refusing to remove the HTTP listener: no HTTPS listener is present.' 'WARN'
+        return
+    }
+
+    $http | ForEach-Object {
+        Write-BootLog "Removing plaintext HTTP listener '$($_.Name)'."
+        Remove-Item -Path "WSMan:\localhost\Listener\$($_.Name)" -Recurse -Force
+    }
+}
+
+try {
+    if (-not (Test-Path $PSScriptRoot)) { New-Item -Path $PSScriptRoot -ItemType Directory -Force | Out-Null }
+
+    # WinRM must be running before the WSMan: drive is usable.
+    $winrm = Get-Service -Name WinRM
+    if ($winrm.Status -ne 'Running') {
+        Write-BootLog 'Starting the WinRM service.'
+        Start-Service -Name WinRM
+    }
+
+    $targets = Get-TargetDnsName
+    $listener = Get-HttpsListener
+
+    if (Test-ListenerCurrent -Listener $listener -RequiredNames $targets -RenewWithinDays $RenewWithinDays) {
+        Write-BootLog "HTTPS listener is current for $($targets -join ', ') - nothing to do."
+    } else {
+        Set-HttpsListener -DnsName $targets -ListenerPort $Port -ValidityYears $CertValidityYears
+    }
+
+    Set-FirewallRule -ListenerPort $Port
+
+    if ($DisableHttpListener) { Remove-HttpListener }
+
+    Write-BootLog 'Completed successfully.'
+} catch {
+    Write-BootLog "Failed: $($_.Exception.Message)" 'ERROR'
+    Write-BootLog $_.ScriptStackTrace 'ERROR'
+    # Deliberately exit 0 - see .NOTES.
+}
+
+exit 0

--- a/ansible/roles/harden/files/Initialize-WinRMHttps.ps1
+++ b/ansible/roles/harden/files/Initialize-WinRMHttps.ps1
@@ -101,6 +101,10 @@ function Test-ListenerCurrent {
 }
 
 function Set-HttpsListener {
+    # Internal helper, always called without -WhatIf. ShouldProcess plumbing
+    # would add a -WhatIf no-op path to a boot script for no benefit.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '')]
     param(
         [string[]]$DnsName,
         [int]$ListenerPort,
@@ -141,6 +145,9 @@ function Set-HttpsListener {
 }
 
 function Set-FirewallRule {
+    # See Set-HttpsListener: internal helper, no -WhatIf path needed.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '')]
     param([int]$ListenerPort)
 
     $name = 'WINRM-HTTPS-In-TCP'
@@ -155,6 +162,11 @@ function Set-FirewallRule {
 }
 
 function Remove-HttpListener {
+    # See Set-HttpsListener: internal helper, no -WhatIf path needed.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '')]
+    param()
+
     $http = Get-ChildItem -Path WSMan:\localhost\Listener -ErrorAction SilentlyContinue |
         Where-Object { $_.Keys -contains 'Transport=HTTP' }
     if (-not $http) { return }

--- a/ansible/roles/harden/tasks/main.yml
+++ b/ansible/roles/harden/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: "{{ harden_task_name }}"
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_facts['os_family'] == "Windows"

--- a/ansible/roles/harden/tasks/windows.yml
+++ b/ansible/roles/harden/tasks/windows.yml
@@ -1,0 +1,164 @@
+---
+# Fleet-wide security baseline for Microsoft Windows templates.
+#
+# SCOPE BOUNDARY — read before adding to this file.
+#
+#   This role carries what EVERY Windows machine in the fleet should have.
+#   Application software does NOT belong here: templates rebuild weekly, and a
+#   stateful application with databases, licences and configuration cannot be
+#   meaningfully baked into a golden image. Per-VM concerns live in that VM's
+#   own repository (see LukeEvansTech/veeam-config for the pattern).
+#
+#   The template's job is to hand over a correctly-configured, hardened OS.
+
+# --- PowerShell 7 -----------------------------------------------------------
+# Windows ships Windows PowerShell 5.1 only. Modern tooling increasingly
+# assumes 7+ (Veeam 13's PowerShell module is the case that surfaced this), so
+# it belongs in the template rather than being installed per-VM.
+- name: Installing PowerShell 7...
+  block:
+    - name: Downloading the PowerShell 7 installer.
+      ansible.windows.win_get_url:
+        url: "{{ harden_powershell_msi_url }}"
+        dest: "{{ harden_powershell_msi_path }}"
+        checksum: "{{ harden_powershell_msi_sha256 }}"
+        checksum_algorithm: sha256
+
+    - name: Installing PowerShell 7.
+      ansible.windows.win_package:
+        path: "{{ harden_powershell_msi_path }}"
+        arguments: /quiet /norestart
+        state: present
+
+    - name: Removing the PowerShell installer.
+      ansible.windows.win_file:
+        path: "{{ harden_powershell_msi_path }}"
+        state: absent
+
+    - name: Verifying PowerShell 7 is present.
+      ansible.windows.win_command: '"{{ harden_powershell_exe }}" -Version'
+      register: harden_powershell_check
+      changed_when: false
+
+    - name: Reporting the installed PowerShell version.
+      ansible.builtin.debug:
+        msg: "{{ harden_powershell_check.stdout | trim }}"
+
+# --- WinRM over HTTPS -------------------------------------------------------
+# Templates historically shipped with a 5985 (HTTP) listener only, so every
+# cloned VM carried remote-management traffic across the LAN in plaintext.
+#
+# The listener cannot simply be created here and baked in: the certificate
+# would carry the TEMPLATE's hostname, and every clone is renamed by vSphere
+# guest customisation. So the template carries a script and a scheduled task,
+# and each machine generates its own certificate on first boot.
+- name: Configuring WinRM over HTTPS...
+  block:
+    - name: Creating the template script directory.
+      ansible.windows.win_file:
+        path: "{{ harden_script_dir }}"
+        state: directory
+
+    - name: Deploying the WinRM HTTPS bootstrap script.
+      ansible.windows.win_copy:
+        src: Initialize-WinRMHttps.ps1
+        dest: "{{ harden_script_dir }}\\Initialize-WinRMHttps.ps1"
+
+    - name: Registering the WinRM HTTPS scheduled task.
+      ansible.windows.win_powershell:
+        parameters:
+          ScriptPath: "{{ harden_script_dir }}\\Initialize-WinRMHttps.ps1"
+          Port: "{{ harden_winrm_https_port }}"
+          ValidityYears: "{{ harden_winrm_cert_validity_years }}"
+          RenewWithinDays: "{{ harden_winrm_cert_renew_within_days }}"
+          DisableHttp: "{{ harden_winrm_disable_http_listener }}"
+        script: |
+          param([string]$ScriptPath, [int]$Port, [int]$ValidityYears,
+                [int]$RenewWithinDays, [bool]$DisableHttp)
+
+          $ErrorActionPreference = 'Stop'
+
+          $argLine = '-NoProfile -NonInteractive -ExecutionPolicy Bypass ' +
+                     ('-File "{0}" -Port {1} -CertValidityYears {2} -RenewWithinDays {3}' -f
+                        $ScriptPath, $Port, $ValidityYears, $RenewWithinDays)
+          if ($DisableHttp) { $argLine += ' -DisableHttpListener' }
+
+          $action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $argLine
+
+          # At boot, because guest customisation renames the clone and the
+          # certificate must follow the new name. Daily as a safety net so a
+          # long-uptime machine still renews before the certificate expires.
+          $atStartup = New-ScheduledTaskTrigger -AtStartup
+          $atStartup.Delay = 'PT1M'
+          $daily = New-ScheduledTaskTrigger -Daily -At '03:00'
+
+          $principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' `
+              -LogonType ServiceAccount -RunLevel Highest
+          $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable `
+              -DontStopOnIdleEnd -MultipleInstances IgnoreNew `
+              -ExecutionTimeLimit (New-TimeSpan -Minutes 10)
+
+          $description = 'Ensures a WinRM HTTPS listener with a certificate ' +
+                         'matching this machine name. Installed by the Packer ' +
+                         'template security baseline.'
+
+          Register-ScheduledTask -TaskName 'Initialize-WinRMHttps' `
+              -Action $action -Trigger $atStartup, $daily `
+              -Principal $principal -Settings $settings -Force `
+              -Description $description | Out-Null
+
+          $Ansible.Changed = $true
+
+    # Run it once during the build. This is the fail-fast check: if the script
+    # is broken it surfaces here, in the Packer log, rather than silently
+    # leaving every future clone without an HTTPS listener. The certificate it
+    # creates carries the build VM's name and is replaced on first boot.
+    - name: Running the WinRM HTTPS bootstrap for the first time.
+      ansible.windows.win_command: >-
+        powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+        -File "{{ harden_script_dir }}\Initialize-WinRMHttps.ps1"
+        -Port {{ harden_winrm_https_port }}
+        -CertValidityYears {{ harden_winrm_cert_validity_years }}
+        -RenewWithinDays {{ harden_winrm_cert_renew_within_days }}
+      register: harden_winrm_bootstrap
+      changed_when: true
+
+    - name: Reporting the bootstrap result.
+      ansible.builtin.debug:
+        var: harden_winrm_bootstrap.stdout_lines
+
+    # The script exits 0 unconditionally so it can never block a boot, which
+    # means its exit code proves nothing. Assert on the listener itself.
+    #
+    # win_powershell (not win_shell) deliberately: the playbook sets
+    # ansible_shell_type=cmd to work around a WinRM encoding bug, so win_shell
+    # would run this through cmd and fail on the PowerShell syntax.
+    - name: Verifying the HTTPS listener is present.
+      ansible.windows.win_powershell:
+        parameters:
+          ExpectedPort: "{{ harden_winrm_https_port }}"
+        script: |
+          param([int]$ExpectedPort)
+          $ErrorActionPreference = 'Stop'
+
+          $listener = Get-ChildItem WSMan:\localhost\Listener |
+            Where-Object { $_.Keys -contains 'Transport=HTTPS' }
+          if (-not $listener) { throw 'No WinRM HTTPS listener was created.' }
+
+          $port = (Get-ChildItem "WSMan:\localhost\Listener\$($listener.Name)" |
+            Where-Object { $_.Name -eq 'Port' }).Value
+          if ([int]$port -ne $ExpectedPort) {
+            throw "HTTPS listener is on port $port, expected $ExpectedPort."
+          }
+
+          $thumb = (Get-ChildItem "WSMan:\localhost\Listener\$($listener.Name)" |
+            Where-Object { $_.Name -eq 'CertificateThumbprint' }).Value
+          $cert = Get-Item "Cert:\LocalMachine\My\$($thumb -replace '\s', '')"
+          "HTTPS listener on $port using certificate $($cert.Subject), valid until $($cert.NotAfter)."
+
+          $Ansible.Changed = $false
+      register: harden_winrm_listener
+
+    - name: Reporting the listener state.
+      ansible.builtin.debug:
+        var: harden_winrm_listener.output

--- a/ansible/roles/harden/vars/main.yml
+++ b/ansible/roles/harden/vars/main.yml
@@ -1,0 +1,2 @@
+---
+harden_task_name: Apply the fleet-wide security baseline.

--- a/ansible/windows-playbook.yml
+++ b/ansible/windows-playbook.yml
@@ -21,3 +21,8 @@
   roles:
     - base
     - configure
+    # Fleet-wide security baseline (WinRM HTTPS, PowerShell 7). Kept as its own
+    # role rather than folded into 'configure': base/configure/clean/users are
+    # vendored from upstream, and keeping our additions in a separate role means
+    # an upstream sync has nothing to conflict with.
+    - harden

--- a/docs/docs/operations/windows.md
+++ b/docs/docs/operations/windows.md
@@ -18,13 +18,108 @@ expensive to find.
   comes from the ESXi product locker (`[] /vmimages/tools-isoimages/windows.iso`)
   — no staging.
 - **WinRM 5985** is the Ansible connection; `win_updates` applies Security +
-  Critical updates.
+  Critical updates. Templates additionally ship an HTTPS listener on 5986 — see
+  [Security baseline](#security-baseline).
 - **vTPM.** `windows-desktop-11` ships `vm_vtpm = true` → the VM gets a Virtual
   TPM, which requires a vCenter **Native Key Provider** (present; check with
   `govc kms.ls`).
 - **`--only` filter.** Datacenter would otherwise build the `dexp` and `core`
   sources together; the matrix `only` field restricts each build to the
   Desktop-Experience source.
+
+## Security baseline
+
+`ansible/roles/harden` carries what *every* Windows machine in the fleet should
+have. It is a separate role on purpose: `base`, `configure`, `clean` and `users`
+are vendored from upstream, so keeping our additions out of them means an
+upstream sync has nothing to conflict with.
+
+**The scope boundary matters.** Application software must not go into a
+template. Templates rebuild weekly, and a stateful application with databases,
+licences and configuration cannot be meaningfully baked into a golden image.
+The template hands over a correctly-configured, hardened OS; anything that makes
+one box a particular application server belongs in that VM's own repository
+(`LukeEvansTech/veeam-config` is the reference pattern).
+
+| Layer | Scope | Lives in |
+| --- | --- | --- |
+| Template Ansible (bake time) | What every Windows Server should have | this repo, `ansible/roles/harden` |
+| Per-VM Ansible (deploy time) | What makes one box an application server | e.g. `LukeEvansTech/veeam-config` |
+
+### WinRM over HTTPS
+
+Templates previously shipped a 5985 (HTTP) listener only, so every cloned VM
+carried credentials and remote-management traffic across the LAN in plaintext.
+
+The listener **cannot be baked into the template**. A certificate generated
+during the build would carry the *build VM's* name, and every clone is renamed
+by vSphere guest customisation — so the certificate would be wrong on all of
+them, and every VM in the fleet would share one private key.
+
+Instead the template ships `C:\ProgramData\PackerTemplate\Initialize-WinRMHttps.ps1`
+and an `Initialize-WinRMHttps` scheduled task. The script:
+
+- runs **at boot** (60s delay) and **daily at 03:00**;
+- is idempotent — a no-op once the listener's certificate covers the current
+  hostname and is outside the 30-day renewal window;
+- regenerates the certificate when the machine is renamed, which is exactly what
+  guest customisation does on first clone;
+- deletes only certificates it created (matched on friendly name), so an
+  operator- or application-installed certificate is never touched;
+- **exits 0 unconditionally.** It runs at boot; a hardening step must never
+  block a machine from starting. Failures land in
+  `C:\ProgramData\PackerTemplate\Initialize-WinRMHttps.log`.
+
+The build runs it once so a broken script fails in the Packer log rather than
+silently leaving every future clone without HTTPS, and the Ansible run then
+asserts the listener actually exists.
+
+**5985 is deliberately left enabled.** Packer's own provisioning — including the
+Ansible run that installs this script — connects over it, so removing it during
+the build would break the build itself. Disabling plaintext is a deploy-time
+decision, not one to bake into the template every Windows VM is cloned from. The
+lever exists when you want it:
+
+```yaml
+harden_winrm_disable_http_listener: true
+```
+
+The script refuses to remove the HTTP listener unless an HTTPS listener is
+actually present, so flipping this cannot lock a machine out of remote
+management.
+
+### PowerShell 7
+
+Windows ships Windows PowerShell 5.1 only, and modern tooling increasingly
+assumes 7+ (Veeam 13's PowerShell module is the case that surfaced this). The
+MSI is installed from the pinned version in `ansible/roles/harden/defaults/main.yml`.
+
+`harden_powershell_version` and `harden_powershell_msi_sha256` are a **matched
+pair — bump both together**, or the checksum check fails the build:
+
+```bash
+curl -sLO https://github.com/PowerShell/PowerShell/releases/download/v<X>/PowerShell-<X>-win-x64.msi
+sha256sum PowerShell-<X>-win-x64.msi
+```
+
+Renovate does not track this pin (it is a plain Ansible var, not a manifest
+entry), so it is a manual bump.
+
+### Verifying on a clone
+
+```powershell
+Test-NetConnection <vm> -Port 5986
+Get-ChildItem WSMan:\localhost\Listener          # on the guest
+& 'C:\Program Files\PowerShell\7\pwsh.exe' -Version
+```
+
+The certificate is self-signed, so a remote session needs to skip CA
+validation:
+
+```powershell
+$so = New-PSSessionOption -SkipCACheck
+Enter-PSSession -ComputerName <vm> -UseSSL -SessionOption $so -Credential (Get-Credential)
+```
 
 ## Gotchas (in the order they bite)
 


### PR DESCRIPTION
Closes #97.

Adds an `ansible/roles/harden` role — run after `base`/`configure` for every Windows line — that carries the fleet-wide security baseline instead of cosmetic OS tidying. Kept as its own role so an upstream sync of the vendored `base`/`configure`/`clean`/`users` roles has nothing to conflict with.

## WinRM over HTTPS (5986)

Templates previously shipped a **5985 (HTTP) listener only**, so every cloned VM carried credentials and remote-management traffic across the LAN in plaintext.

The listener **cannot be baked into the template**: a certificate generated during the Packer build carries the *build VM's* name, and every clone is renamed by vSphere guest customisation — so it would be wrong on all of them and every VM would share one private key. Instead the template ships `C:\ProgramData\PackerTemplate\Initialize-WinRMHttps.ps1` and an `Initialize-WinRMHttps` scheduled task that, at boot (+1 min) and daily:

- generates a self-signed cert matching the machine's current hostname (short + FQDN when domain-joined),
- is idempotent — a no-op once the cert covers the hostname and is outside the 30-day renewal window,
- regenerates on rename (exactly what guest customisation does on first clone),
- deletes only certs it created, and **exits 0 unconditionally** (a hardening step must never block a boot; failures go to a log file).

The build runs it once as a fail-fast check and then asserts the listener actually exists.

**5985 is deliberately left enabled.** Packer's own provisioning — including the Ansible run that installs this script — connects over it, so removing it during the build would break the build itself. Disabling plaintext is a deploy-time decision; the lever exists (`harden_winrm_disable_http_listener`, defaulted off) and the script refuses to remove HTTP unless HTTPS is already listening, so flipping it can't lock a box out.

## PowerShell 7

Windows ships Windows PowerShell 5.1 only; modern tooling (Veeam 13's PowerShell module) requires 7+. Installed from a pinned, checksummed MSI (`harden_powershell_version` / `harden_powershell_msi_sha256` in the role defaults — a matched pair, bumped by hand since Renovate doesn't track a plain Ansible var).

## Scope boundary

Application software stays out of the template — templates rebuild weekly and are fleet-wide; per-VM concerns live in that VM's own repo (`LukeEvansTech/veeam-config`). Documented under `docs/docs/operations/windows.md`.

## Verification

- `ansible-lint` — clean at the `production` profile on the new role
- **super-linter v8.6.0** (the CI gate, run locally) — `YAML_PRETTIER` / `ANSIBLE` / `POWERSHELL` clean on all changed files
- PowerShell parse + PSScriptAnalyzer — clean (remaining findings are `ShouldProcess` on internal helpers, intentionally not plumbed)
- `packer fmt -check` — pass (no HCL changed)
- `zensical build` — pass, page renders

**Remaining:** a real end-to-end Windows build (`gh workflow run build-templates.yml -f os=windows-server-2025`) is the last check — not run here (~4 h, needs vSphere). Note the weekly build is currently red for an unrelated ARC-runner init failure (issue #94).

https://claude.ai/code/session_011tHjqC3JjBPh9FaF6RdE8J